### PR TITLE
refactor: use updated Sourcegraph extension API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2072,17 +2072,6 @@
         }
       }
     },
-    "cxp": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/cxp/-/cxp-6.4.0.tgz",
-      "integrity": "sha512-X0M+aNgnODGe2dlmdqHienGJyf26JZaH2FNTKlslrG/Ar14a61TlgddGS62mG8z/mCvLgW0n4nS+axgD3xgBGA==",
-      "requires": {
-        "minimatch": "^3.0.4",
-        "rxjs": "^6.2.1",
-        "uuid": "^3.3.2",
-        "vscode-languageserver-types": "^3.8.2"
-      }
-    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -8309,14 +8298,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "rxjs": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -8659,6 +8640,27 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "sourcegraph": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/sourcegraph/-/sourcegraph-14.1.1.tgz",
+      "integrity": "sha512-UMJxlJCC2tIFEWTXax1b3BkGbIWrrEsuGL4+ciXKv78KgucFYayTzH77r/9OW5htLNy6Bi5D3PNL8p696nkaxA==",
+      "requires": {
+        "minimatch": "^3.0.4",
+        "rxjs": "^6.3.2",
+        "uuid": "^3.3.2",
+        "vscode-languageserver-types": "^3.12.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+          "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
+      }
     },
     "split-string": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
-    "cxp": "^6.4.0",
+    "sourcegraph": "^14.1.1",
     "vscode-languageserver-types": "^3.12.0"
   },
   "sideEffects": false

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { Handler, Config } from './handler'
-import { TextDocumentPositionParams } from 'cxp/module/protocol'
+import { TextDocumentPositionParams } from 'sourcegraph/module/protocol'
 import { Result } from './api'
 
 interface ConfigTest {
@@ -45,9 +45,7 @@ describe('config tests', () => {
 
         for (const test of tests) {
             const h = new Handler({
-                root: null,
                 capabilities: {},
-                workspaceFolders: [],
                 configurationCascade: {
                     merged: { ...test.input },
                 },
@@ -59,9 +57,8 @@ describe('config tests', () => {
         let gotErr = false
         try {
             new Handler({
-                root: null,
                 capabilities: {},
-                workspaceFolders: [],
+                configurationCascade: { merged: {} },
             })
         } catch (err) {
             gotErr = true
@@ -139,9 +136,7 @@ describe('search requests', () => {
 
         for (const test of tests) {
             const h = new Handler({
-                root: null,
                 capabilities: {},
-                workspaceFolders: [],
                 configurationCascade: {
                     merged: {
                         'basicCodeIntel.sourcegraphToken': 'TOKEN',
@@ -185,9 +180,7 @@ describe('search requests', () => {
 
         for (const test of tests) {
             const h = new Handler({
-                root: null,
                 capabilities: {},
-                workspaceFolders: [],
                 configurationCascade: {
                     merged: {
                         'basicCodeIntel.sourcegraphToken': 'TOKEN',

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -2,8 +2,8 @@ import {
     TextDocumentPositionParams,
     ReferenceParams,
     InitializeParams,
-} from 'cxp/module/protocol'
-import { DidOpenTextDocumentParams } from 'cxp/module/protocol/textDocument'
+} from 'sourcegraph/module/protocol'
+import { DidOpenTextDocumentParams } from 'sourcegraph/module/protocol/textDocument'
 import { API, Result } from './api'
 import { Location } from 'vscode-languageserver-types'
 


### PR DESCRIPTION
Migrates from the old CXP API.

TODOs:

- I discovered my recent updates to the Sourcegraph extension API make it impossible for extensions to get the contents of the *first* document opened (ie they can never get the first textDocument/didOpen notification's params). I will fix this.