### PR TITLE
Clojure: add slash `/` to recognized characters

### DIFF
--- a/shared/language-specs/languages.ts
+++ b/shared/language-specs/languages.ts
@@ -446,7 +446,7 @@ export const languageSpecs: LanguageSpec[] = [
             languageID: 'clojure',
             fileExts: ['clj', 'cljs', 'cljx'],
             commentStyle: lispStyle,
-            identCharPattern: /[A-Za-z0-9_\-!?+*<>=]/,
+            identCharPattern: /[A-Za-z0-9_\-!?+*<>=/]/,
         },
         stylized: 'Clojure',
     },


### PR DESCRIPTION
Requested at https://github.com/sourcegraph/sourcegraph/issues/3614#issuecomment-581636768

**Edit** Hang on, I might have misinterpreted the request as relating to symbol names instead of definition keywords.