### PR TITLE
Support multiple comment styles per language.

### DIFF
--- a/shared/language-specs/comments.ts
+++ b/shared/language-specs/comments.ts
@@ -12,22 +12,27 @@ export const hashPattern = /#\s?/
 /** Matches two or more dashes followed by one optional space. */
 export const dashPattern = /---*\s?/
 
-// TODO - does not need to be optional?
-/** Matches whitespace followed by a asterisk at the beginning of a line. */
-export const leadingAsteriskPattern = /(^\s*\*\s?)?/
-
 /** Matches whitespace followed by an at-symbol at beginning of a line. */
 export const leadingAtSymbolPattern = /^\s*@/
+
+/** Matches whitespace followed by a hash symbol at beginning of a line. */
+export const leadingHashPattern = /^\s*#/
 
 export const cStyleBlockComment: BlockCommentStyle = {
     startRegex: /\/\*\*?/,
     endRegex: /\*\//,
-    lineNoiseRegex: leadingAsteriskPattern,
+    lineNoiseRegex: /\s*\*\s?/,
 }
 
 export const cStyleComment: CommentStyle = {
     lineRegex: slashPattern,
     block: cStyleBlockComment,
+}
+
+/** C-style comments that ignore lines with @annotations. */
+export const javaStyleComment: CommentStyle = {
+    ...cStyleComment,
+    docstringIgnore: leadingAtSymbolPattern,
 }
 
 export const shellStyleComment: CommentStyle = {

--- a/shared/language-specs/cpp.ts
+++ b/shared/language-specs/cpp.ts
@@ -60,7 +60,7 @@ export const cppSpec: LanguageSpec = {
         'ino', // Arduino
         'm', // Objective-C
     ],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
     filterDefinitions,
 }
 
@@ -68,6 +68,6 @@ export const cudaSpec: LanguageSpec = {
     languageID: 'cuda',
     stylized: 'CUDA',
     fileExts: ['cu', 'cuh'],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
     filterDefinitions,
 }

--- a/shared/language-specs/go.ts
+++ b/shared/language-specs/go.ts
@@ -47,6 +47,6 @@ export const goSpec: LanguageSpec = {
     languageID: 'go',
     stylized: 'Go',
     fileExts: ['go'],
-    commentStyle: { lineRegex: slashPattern },
+    commentStyles: [{ lineRegex: slashPattern }],
     filterDefinitions,
 }

--- a/shared/language-specs/identifiers.ts
+++ b/shared/language-specs/identifiers.ts
@@ -2,7 +2,8 @@
  * Create an identifier char pattern that matches alphanum and underscore plus any
  * additional extra characters that are supplied.
  *
- * @param extraChars Extra characters to add to pattern. Must escape special chars.
+ * @param extraChars Extra characters to add to pattern. It is expected that
+ *        any special regex chars are escaped for use in a character class.
  */
 export function createIdentCharPattern(extraChars: string): RegExp {
     return new RegExp(`[A-Za-z0-9_${extraChars}]`)

--- a/shared/language-specs/java.ts
+++ b/shared/language-specs/java.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { cStyleComment, leadingAtSymbolPattern } from './comments'
+import { javaStyleComment } from './comments'
 import { FilterContext, LanguageSpec, Result } from './spec'
 import { extractFromLines, filterResultsByImports, slashToDot } from './util'
 
@@ -37,7 +37,6 @@ export const javaSpec: LanguageSpec = {
     languageID: 'java',
     stylized: 'Java',
     fileExts: ['java'],
-    commentStyle: cStyleComment,
-    docstringIgnore: leadingAtSymbolPattern,
+    commentStyles: [javaStyleComment],
     filterDefinitions,
 }

--- a/shared/language-specs/languages.ts
+++ b/shared/language-specs/languages.ts
@@ -1,10 +1,9 @@
 import {
-    cStyleBlockComment,
     cStyleComment,
     dashPattern,
-    hashPattern,
-    leadingAsteriskPattern,
+    javaStyleComment,
     leadingAtSymbolPattern,
+    leadingHashPattern,
     lispStyleComment,
     pythonStyleComment,
     shellStyleComment,
@@ -23,22 +22,22 @@ const clojureSpec: LanguageSpec = {
     languageID: 'clojure',
     stylized: 'Clojure',
     fileExts: ['clj', 'cljs', 'cljx'],
-    identCharPattern: createIdentCharPattern('-!?+*<>='),
-    commentStyle: lispStyleComment,
+    identCharPattern: createIdentCharPattern('\\-!?+*<>='),
+    commentStyles: [lispStyleComment],
 }
 
 const csharpSpec: LanguageSpec = {
     languageID: 'csharp',
     stylized: 'C#',
     fileExts: ['cs', 'csx'],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
 }
 
 const dartSpec: LanguageSpec = {
     languageID: 'dart',
     stylized: 'Dart',
     fileExts: ['dart'],
-    commentStyle: { lineRegex: tripleSlashPattern },
+    commentStyles: [{ lineRegex: tripleSlashPattern }],
 }
 
 const elixirSpec: LanguageSpec = {
@@ -46,105 +45,126 @@ const elixirSpec: LanguageSpec = {
     stylized: 'Elixir',
     fileExts: ['ex', 'exs'],
     identCharPattern: rubyIdentCharPattern,
-    commentStyle: {
-        ...pythonStyleComment,
-        docPlacement: 'above the definition',
-    },
-    docstringIgnore: leadingAtSymbolPattern,
+    commentStyles: [
+        {
+            ...pythonStyleComment,
+            docPlacement: 'above the definition',
+            docstringIgnore: leadingAtSymbolPattern,
+        },
+    ],
 }
 
 const erlangSpec: LanguageSpec = {
     languageID: 'erlang',
     stylized: 'Erlang',
     fileExts: ['erl'],
-    commentStyle: {
-        // %% comment
-        lineRegex: /%%\s?/,
-    },
-    docstringIgnore: /-spec/,
+    commentStyles: [
+        {
+            // %% comment
+            lineRegex: /%%\s?/,
+            // -spec id(X) -> X.
+            docstringIgnore: /^\s*-spec/,
+        },
+    ],
 }
 
 const graphqlSpec: LanguageSpec = {
     languageID: 'graphql',
     stylized: 'GraphQL',
     fileExts: ['graphql'],
-    commentStyle: shellStyleComment,
+    commentStyles: [shellStyleComment],
 }
 
 const groovySpec: LanguageSpec = {
     languageID: 'groovy',
     stylized: 'Groovy',
     fileExts: ['groovy'],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
 }
+
+// {-# PRAGMA args #-}
+const haskellPragma = /^\s*{-#\s*[A-Z]+.*#-}$/
 
 const haskellSpec: LanguageSpec = {
     languageID: 'haskell',
     stylized: 'Haskell',
     fileExts: ['hs', 'hsc'],
     identCharPattern: createIdentCharPattern("'"),
-    commentStyle: {
-        // -- comment
-        // -- | doc comment
-        // {- block comment -}
-        // TODO - (support -- ^ doc comment)
-        lineRegex: /--\s?\|?\s?/,
-        block: { startRegex: /{-/, endRegex: /-}/ },
-    },
-    docstringIgnore: /INLINE|^#/,
+    commentStyles: [
+        {
+            // -- comment
+            // -- | doc comment
+            // {- block comment -}
+            lineRegex: /--\s?\|?\s?/,
+            block: { startRegex: /{-/, endRegex: /-}/ },
+            docstringIgnore: haskellPragma,
+        },
+        {
+            // -- ^ doc comment
+            lineRegex: /--\s?\^?\s?/,
+            docPlacement: 'above the definition',
+            docstringIgnore: haskellPragma,
+        },
+    ],
 }
 
 const kotlinSpec: LanguageSpec = {
     languageID: 'kotlin',
     stylized: 'Kotlin',
     fileExts: ['kt', 'ktm', 'kts'],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
 }
 
 const lispSpec: LanguageSpec = {
     languageID: 'lisp',
     stylized: 'Lisp',
     fileExts: ['lisp', 'asd', 'cl', 'lsp', 'l', 'ny', 'podsl', 'sexp', 'el'],
-    identCharPattern: createIdentCharPattern('-!?'),
-    commentStyle: lispStyleComment,
+    identCharPattern: createIdentCharPattern('\\-!?'),
+    commentStyles: [lispStyleComment],
 }
 
 const luaSpec: LanguageSpec = {
     languageID: 'lua',
     stylized: 'Lua',
     fileExts: ['lua', 'fcgi', 'nse', 'pd_lua', 'rbxs', 'wlua'],
-    commentStyle: {
-        // --[[ block comment ]]
-        lineRegex: dashPattern,
-        block: { startRegex: /--\[\[/, endRegex: /\]\]/ },
-    },
+    commentStyles: [
+        {
+            // --[[ block comment ]]
+            lineRegex: dashPattern,
+            block: { startRegex: /--\[\[/, endRegex: /\]\]/ },
+        },
+    ],
 }
 
 const ocamlSpec: LanguageSpec = {
     languageID: 'ocaml',
     stylized: 'OCaml',
     fileExts: ['ml', 'eliom', 'eliomi', 'ml4', 'mli', 'mll', 'mly', 're'],
-    commentStyle: {
-        // (* block comment *)
-        // (** block comment *)
-        block: {
-            startRegex: /\(\*\*?/,
-            endRegex: /\*\)/,
-            lineNoiseRegex: leadingAsteriskPattern,
+    commentStyles: [
+        {
+            // (* block comment *)
+            // (** block comment *)
+            block: {
+                startRegex: /\(\*\*?/,
+                endRegex: /\*\)/,
+                lineNoiseRegex: /\s*\*\s?/,
+            },
         },
-    },
+    ],
 }
 
 const pascalSpec: LanguageSpec = {
     languageID: 'pascal',
     stylized: 'Pascal',
     fileExts: ['p', 'pas', 'pp'],
-    commentStyle: {
-        // (* block comment *)
-        // { turbo pascal block comment }
-        lineRegex: slashPattern,
-        block: { startRegex: /(\{|\(\*)\s?/, endRegex: /(\}|\*\))/ },
-    },
+    commentStyles: [
+        {
+            // (* block comment *)
+            // { turbo pascal block comment }
+            lineRegex: slashPattern,
+            block: { startRegex: /(\{|\(\*)\s?/, endRegex: /(\}|\*\))/ },
+        },
+    ],
 }
 
 const perlSpec: LanguageSpec = {
@@ -163,14 +183,14 @@ const perlSpec: LanguageSpec = {
         'psgi',
         't',
     ],
-    commentStyle: { lineRegex: hashPattern },
+    commentStyles: [shellStyleComment],
 }
 
 const phpSpec: LanguageSpec = {
     languageID: 'php',
     stylized: 'PHP',
     fileExts: ['php', 'phtml', 'php3', 'php4', 'php5', 'php6', 'php7', 'phps'],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
 }
 
 const powershellSpec: LanguageSpec = {
@@ -178,12 +198,15 @@ const powershellSpec: LanguageSpec = {
     stylized: 'PowerShell',
     fileExts: ['ps1', 'psd1', 'psm1'],
     identCharPattern: createIdentCharPattern('?'),
-    commentStyle: {
-        // <# doc comment #>
-        block: { startRegex: /<#/, endRegex: /#>/ },
-        docPlacement: 'below the definition',
-    },
-    docstringIgnore: /\{/,
+    commentStyles: [
+        {
+            // <# doc comment #>
+            block: { startRegex: /<#/, endRegex: /#>/ },
+            docPlacement: 'below the definition',
+            // any line with braces
+            docstringIgnore: /\{/,
+        },
+    ],
 }
 
 const rSpec: LanguageSpec = {
@@ -193,7 +216,7 @@ const rSpec: LanguageSpec = {
     identCharPattern: createIdentCharPattern('.'),
     // # comment
     // #' comment
-    commentStyle: { lineRegex: /#'?\s?/ },
+    commentStyles: [{ lineRegex: /#'?\s?/ }],
 }
 
 const rubySpec: LanguageSpec = {
@@ -221,7 +244,7 @@ const rubySpec: LanguageSpec = {
         'thor',
         'watchr',
     ],
-    commentStyle: shellStyleComment,
+    commentStyles: [shellStyleComment],
     identCharPattern: rubyIdentCharPattern,
 }
 
@@ -229,50 +252,52 @@ const rustSpec: LanguageSpec = {
     languageID: 'rust',
     stylized: 'Rust',
     fileExts: ['rs', 'rs.in'],
-    commentStyle: {
-        // TODO - (support above/below)
-        // //! doc comment
-        lineRegex: /\/\/\/?!?\s?/,
-        block: cStyleBlockComment,
-    },
-    docstringIgnore: /^#/,
+    commentStyles: [
+        {
+            ...cStyleComment,
+            docstringIgnore: leadingHashPattern,
+        },
+        {
+            lineRegex: /\/\/?!\s?/,
+            docstringIgnore: leadingHashPattern,
+            docPlacement: 'below the definition',
+        },
+    ],
 }
 
 const scalaSpec: LanguageSpec = {
     languageID: 'scala',
     stylized: 'Scala',
     fileExts: ['sbt', 'sc', 'scala'],
-    commentStyle: cStyleComment,
-    docstringIgnore: leadingAtSymbolPattern,
+    commentStyles: [javaStyleComment],
 }
 
 const shellSpec: LanguageSpec = {
     languageID: 'shell',
     stylized: 'Shell',
     fileExts: ['sh', 'bash', 'zsh'],
-    commentStyle: shellStyleComment,
+    commentStyles: [shellStyleComment],
 }
 
 const swiftSpec: LanguageSpec = {
     languageID: 'swift',
     stylized: 'Swift',
     fileExts: ['swift'],
-    commentStyle: cStyleComment,
-    docstringIgnore: leadingAtSymbolPattern,
+    commentStyles: [javaStyleComment],
 }
 
 const verilogSpec: LanguageSpec = {
     languageID: 'verilog',
     stylized: 'Verilog',
     fileExts: ['sv', 'svh', 'svi', 'v'],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
 }
 
 const vhdlSpec: LanguageSpec = {
     languageID: 'vhdl',
     stylized: 'VHDL',
     fileExts: ['vhd', 'vhdl'],
-    commentStyle: { lineRegex: dashPattern },
+    commentStyles: [{ lineRegex: dashPattern }],
 }
 
 /**

--- a/shared/language-specs/languages.ts
+++ b/shared/language-specs/languages.ts
@@ -102,7 +102,7 @@ const haskellSpec: LanguageSpec = {
         {
             // -- ^ doc comment
             lineRegex: /--\s?\^?\s?/,
-            docPlacement: 'above the definition',
+            docPlacement: 'below the definition',
             docstringIgnore: haskellPragma,
         },
     ],

--- a/shared/language-specs/python.ts
+++ b/shared/language-specs/python.ts
@@ -79,6 +79,6 @@ export const pythonSpec: LanguageSpec = {
     languageID: 'python',
     stylized: 'Python',
     fileExts: ['py'],
-    commentStyle: pythonStyleComment,
+    commentStyles: [pythonStyleComment],
     filterDefinitions,
 }

--- a/shared/language-specs/spec.ts
+++ b/shared/language-specs/spec.ts
@@ -26,15 +26,9 @@ export interface LanguageSpec {
     identCharPattern?: RegExp
 
     /**
-     * Instruction on how to parse comments in order to extract docstrings.
+     * Instructions on how to parse comments in order to extract docstrings.
      */
-    commentStyle?: CommentStyle
-
-    /**
-     * Regex that matches lines between a definition and the docstring that
-     * should be ignored. Java example: `/^\s*@/` for annotations.
-     */
-    docstringIgnore?: RegExp
+    commentStyles: CommentStyle[]
 
     /**
      * Callback that filters the given symbol search results (e.g. to drop
@@ -65,6 +59,12 @@ export interface CommentStyle {
      * `'below the definition'`.
      */
     docPlacement?: DocPlacement
+
+    /**
+     * Regex that matches lines between a definition and the docstring that
+     * should be ignored. Java example: `/^\s*@/` for class/method annotations.
+     */
+    docstringIgnore?: RegExp
 }
 
 /**

--- a/shared/language-specs/typescript.ts
+++ b/shared/language-specs/typescript.ts
@@ -49,6 +49,6 @@ export const typescriptSpec: LanguageSpec = {
     languageID: 'typescript',
     stylized: 'TypeScript',
     fileExts: ['ts', 'tsx', 'js', 'jsx'],
-    commentStyle: cStyleComment,
+    commentStyles: [cStyleComment],
     filterDefinitions,
 }

--- a/shared/search/docstrings.test.ts
+++ b/shared/search/docstrings.test.ts
@@ -1,6 +1,12 @@
 import * as assert from 'assert'
-import { cStyleComment, pythonStyleComment } from '../language-specs/comments'
+import {
+    cStyleComment,
+    javaStyleComment,
+    pythonStyleComment,
+    leadingHashPattern,
+} from '../language-specs/comments'
 import { findDocstring } from './docstrings'
+import { CommentStyle } from '../language-specs/spec'
 
 describe('docstrings', () => {
     it('finds nothing when no comment style is specified', () => {
@@ -12,6 +18,7 @@ describe('docstrings', () => {
             pass
         `,
                 definitionLine: 1,
+                commentStyles: [],
             }),
             undefined
         )
@@ -26,7 +33,7 @@ describe('docstrings', () => {
             pass
         `,
                 definitionLine: 1,
-                commentStyle: pythonStyleComment,
+                commentStyles: [pythonStyleComment],
             }),
             'docstring'
         )
@@ -42,7 +49,7 @@ describe('docstrings', () => {
             pass
         `,
                 definitionLine: 1,
-                commentStyle: pythonStyleComment,
+                commentStyles: [pythonStyleComment],
             }),
             'docstring1\ndocstring2'
         )
@@ -59,7 +66,7 @@ describe('docstrings', () => {
             pass
         `,
                 definitionLine: 1,
-                commentStyle: pythonStyleComment,
+                commentStyles: [pythonStyleComment],
             }),
             'docstring1\ndocstring2\n'
         )
@@ -77,7 +84,7 @@ describe('docstrings', () => {
             pass
         `,
                 definitionLine: 1,
-                commentStyle: pythonStyleComment,
+                commentStyles: [pythonStyleComment],
             }),
             '\ndocstring1\ndocstring2\n'
         )
@@ -91,7 +98,7 @@ describe('docstrings', () => {
         const foo;
         `,
                 definitionLine: 2,
-                commentStyle: cStyleComment,
+                commentStyles: [cStyleComment],
             }),
             'docstring'
         )
@@ -106,7 +113,7 @@ describe('docstrings', () => {
         const foo;
         `,
                 definitionLine: 3,
-                commentStyle: cStyleComment,
+                commentStyles: [cStyleComment],
             }),
             'docstring1\ndocstring2'
         )
@@ -122,7 +129,7 @@ describe('docstrings', () => {
         const foo;
         `,
                 definitionLine: 4,
-                commentStyle: cStyleComment,
+                commentStyles: [cStyleComment],
             }),
             'docstring1\ndocstring2\n'
         )
@@ -137,7 +144,7 @@ describe('docstrings', () => {
         const foo;
         `,
                 definitionLine: 3,
-                commentStyle: cStyleComment,
+                commentStyles: [cStyleComment],
             }),
             'docstring1\ndocstring2 '
         )
@@ -152,7 +159,7 @@ describe('docstrings', () => {
         const foo;
         `,
                 definitionLine: 3,
-                commentStyle: cStyleComment,
+                commentStyles: [cStyleComment],
             }),
             ' docstring1\ndocstring2'
         )
@@ -169,10 +176,41 @@ describe('docstrings', () => {
         public void FizzBuzz()
         `,
                 definitionLine: 5,
-                commentStyle: cStyleComment,
-                docstringIgnore: /^\s*@/,
+                commentStyles: [javaStyleComment],
             }),
             '\ndocstring\n'
+        )
+    })
+
+    it('searches multiple comment styles', () => {
+        const fileText = `
+        mod foo {
+            //! Comment below the def
+
+            /// Comment above the def
+            pub fn new(value: T) -> Rc<T> {
+        }
+        `
+
+        const commentStyles: CommentStyle[] = [
+            {
+                ...cStyleComment,
+                docstringIgnore: leadingHashPattern,
+            },
+            {
+                lineRegex: /\/\/\/?!?\s?/,
+                docstringIgnore: leadingHashPattern,
+                docPlacement: 'below the definition',
+            },
+        ]
+
+        assert.deepStrictEqual(
+            findDocstring({ fileText, definitionLine: 1, commentStyles }),
+            'Comment below the def'
+        )
+        assert.deepStrictEqual(
+            findDocstring({ fileText, definitionLine: 5, commentStyles }),
+            'Comment above the def'
         )
     })
 })

--- a/shared/search/docstrings.ts
+++ b/shared/search/docstrings.ts
@@ -13,64 +13,67 @@ import {
 export function findDocstring({
     definitionLine,
     fileText,
-    commentStyle,
-    docstringIgnore,
+    commentStyles,
 }: {
     /** The index of the definition. */
     definitionLine: number
     /** The source of the file. */
     fileText: string
     /** The comment style of the current language. */
-    commentStyle?: CommentStyle
-    /** An optional pattern to ignore before the docstring. */
-    docstringIgnore?: RegExp
+    commentStyles: CommentStyle[]
 }): string | undefined {
-    if (!commentStyle) {
-        return undefined
-    }
-    const { lineRegex, block, docPlacement } = commentStyle
-
     const allLines = fileText.split('\n')
 
-    const sameLineDocstring = findDocstringOnDefinitionLine(
-        allLines[definitionLine],
-        { lineRegex, block }
-    )
-    if (sameLineDocstring) {
-        return sameLineDocstring
-    }
-
-    if (lineRegex) {
-        const lineCommentDocstring = findDocstringInLineComments({
-            lineRegex,
-            lines: mungeLines(allLines, docPlacement, definitionLine),
-            docstringIgnore,
-        })
-        if (lineCommentDocstring) {
-            return unmungeLines(lineCommentDocstring, docPlacement).join('\n')
+    for (const {
+        lineRegex,
+        block,
+        docstringIgnore,
+        docPlacement,
+    } of commentStyles) {
+        const sameLineDocstring = findDocstringOnDefinitionLine(
+            allLines[definitionLine],
+            { lineRegex, block }
+        )
+        if (sameLineDocstring) {
+            return sameLineDocstring
         }
-    }
 
-    if (block) {
-        // If we've reversed the lines we also need to reverse the
-        // block delimiter patterns.
+        if (lineRegex) {
+            const lineCommentDocstring = findDocstringInLineComments({
+                lineRegex,
+                lines: mungeLines(allLines, docPlacement, definitionLine),
+                docstringIgnore,
+            })
+            if (lineCommentDocstring) {
+                return unmungeLines(lineCommentDocstring, docPlacement).join(
+                    '\n'
+                )
+            }
+        }
 
-        const modifiedBlock =
-            docPlacement === 'below the definition'
-                ? block
-                : {
-                      startRegex: block.endRegex,
-                      endRegex: block.startRegex,
-                      lineNoiseRegex: block.lineNoiseRegex,
-                  }
+        if (block) {
+            // If we've reversed the lines we also need to reverse the
+            // block delimiter patterns.
 
-        const blockCommentDocstring = findDocstringInBlockComment({
-            block: modifiedBlock,
-            lines: mungeLines(allLines, docPlacement, definitionLine),
-            docstringIgnore,
-        })
-        if (blockCommentDocstring) {
-            return unmungeLines(blockCommentDocstring, docPlacement).join('\n')
+            const modifiedBlock =
+                docPlacement === 'below the definition'
+                    ? block
+                    : {
+                          startRegex: block.endRegex,
+                          endRegex: block.startRegex,
+                          lineNoiseRegex: block.lineNoiseRegex,
+                      }
+
+            const blockCommentDocstring = findDocstringInBlockComment({
+                block: modifiedBlock,
+                lines: mungeLines(allLines, docPlacement, definitionLine),
+                docstringIgnore,
+            })
+            if (blockCommentDocstring) {
+                return unmungeLines(blockCommentDocstring, docPlacement).join(
+                    '\n'
+                )
+            }
         }
     }
 
@@ -225,7 +228,7 @@ function findDocstringInBlockComment({
 
     // Eat all comment lines until we find the end delimiter. Notice that we've
     // already removed the opening delimiter. The ordering of these operations
-    // are necessary for doc blocks in langauges like Python that have identical
+    // are necessary for doc blocks in languages like Python that have identical
     // open and closing delimiters.
 
     const docLines = takeWhileInclusive(

--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -24,9 +24,8 @@ import { findSearchToken } from './tokens'
 export function createProviders({
     languageID,
     fileExts = [],
-    commentStyle,
+    commentStyles,
     identCharPattern,
-    docstringIgnore,
     filterDefinitions: filterDefinitions = results => results,
 }: LanguageSpec): Providers {
     /**
@@ -49,7 +48,9 @@ export function createProviders({
         const tokenResult = findSearchToken({
             text,
             position: pos,
-            lineRegex: commentStyle?.lineRegex,
+            lineRegexes: commentStyles
+                .map(style => style.lineRegex)
+                .filter(isDefined),
             identCharPattern,
         })
         if (!tokenResult || tokenResult.isComment) {
@@ -209,8 +210,7 @@ export function createProviders({
         const docstring = findDocstring({
             definitionLine: def.range.start.line,
             fileText: text,
-            commentStyle,
-            docstringIgnore,
+            commentStyles,
         })
 
         const docstringMarkdown =

--- a/shared/search/tokens.test.ts
+++ b/shared/search/tokens.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { findSearchToken } from './tokens'
+import { slashPattern } from '../language-specs/comments'
 
 describe('findSearchToken', () => {
     it('custom identCharPattern', () => {
@@ -7,6 +8,7 @@ describe('findSearchToken', () => {
             findSearchToken({
                 text: '(defn skip-ws! []',
                 position: { line: 0, character: 6 },
+                lineRegexes: [],
                 identCharPattern: /[A-Za-z0-9_\-!?]/,
             }),
             {
@@ -21,7 +23,7 @@ describe('findSearchToken', () => {
             findSearchToken({
                 text: 'foo bar // baz',
                 position: { line: 0, character: 5 },
-                lineRegex: /\/\//,
+                lineRegexes: [slashPattern],
             }),
             {
                 searchToken: 'bar',
@@ -35,7 +37,7 @@ describe('findSearchToken', () => {
             findSearchToken({
                 text: 'foo // bar baz',
                 position: { line: 0, character: 8 },
-                lineRegex: /\/\//,
+                lineRegexes: [slashPattern],
             }),
             {
                 searchToken: 'bar',
@@ -49,7 +51,7 @@ describe('findSearchToken', () => {
             findSearchToken({
                 text: 'foo // bar(baz)',
                 position: { line: 0, character: 8 },
-                lineRegex: /\/\//,
+                lineRegexes: [slashPattern],
             }),
             {
                 searchToken: 'bar',
@@ -63,7 +65,7 @@ describe('findSearchToken', () => {
             findSearchToken({
                 text: 'foo // .bar baz',
                 position: { line: 0, character: 9 },
-                lineRegex: /\/\//,
+                lineRegexes: [slashPattern],
             }),
             {
                 searchToken: 'bar',
@@ -77,7 +79,7 @@ describe('findSearchToken', () => {
             findSearchToken({
                 text: 'foo // "bar" baz',
                 position: { line: 0, character: 9 },
-                lineRegex: /\/\//,
+                lineRegexes: [slashPattern],
             }),
             {
                 searchToken: 'bar',
@@ -91,7 +93,7 @@ describe('findSearchToken', () => {
             findSearchToken({
                 text: 'foo // "bar baz"',
                 position: { line: 0, character: 9 },
-                lineRegex: /\/\//,
+                lineRegexes: [slashPattern],
             }),
             {
                 searchToken: 'bar',

--- a/shared/search/tokens.ts
+++ b/shared/search/tokens.ts
@@ -15,7 +15,7 @@ const DEFAULT_IDENT_CHAR_PATTERN = /[A-Za-z0-9_]/
 export function findSearchToken({
     text,
     position,
-    lineRegex,
+    lineRegexes,
     identCharPattern = DEFAULT_IDENT_CHAR_PATTERN,
 }: {
     /** The text of the current document. */
@@ -23,7 +23,7 @@ export function findSearchToken({
     /** The current hover position. */
     position: { line: number; character: number }
     /** The pattern that identifies a line comment. */
-    lineRegex?: RegExp
+    lineRegexes: RegExp[]
     /** The pattern that identifies identifiers in this language. */
     identCharPattern?: RegExp
 }): { searchToken: string; isComment: boolean } | undefined {
@@ -55,14 +55,12 @@ export function findSearchToken({
 
     const searchToken = line.substring(start, end)
 
-    if (!lineRegex) {
-        // No comment to check for
-        return { searchToken, isComment: false }
-    }
-
-    const match = line.match(lineRegex)
-    if (!match || match.index === undefined || match.index > start) {
-        // No comment on this line, or it occurs after the token
+    if (
+        !lineRegexes.some(
+            // comment on this line occurring before the token
+            lineRegex => (line.match(lineRegex)?.index || 0) < start
+        )
+    ) {
         return { searchToken, isComment: false }
     }
 


### PR DESCRIPTION
Some languages like rust and haskell have particular comment styles that are legal only above or below a definition, but both are defined in the language.

`-- | is a comment above in haskell`

`-- ^ is a comment below in haskell`

`//! documents the containing scope in rust`

`/// documents the next declaration in rust`