### PR TITLE
Add support for LSP cancellation tokens

### DIFF
--- a/extensions/typescript/src/extension.ts
+++ b/extensions/typescript/src/extension.ts
@@ -1,3 +1,4 @@
+import { CancellationTokenSource } from '@sourcegraph/vscode-ws-jsonrpc'
 import { Subject } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 import { activateCodeIntel } from '../../../shared/activate'
@@ -140,9 +141,13 @@ async function registerClient(
     client: LSPClient
     featureOptionsSubject: Subject<FeatureOptions>
 }> {
+    const cancellationTokenSource = new CancellationTokenSource()
+    const cancellationToken = cancellationTokenSource.token
+
     const transport = webSocketTransport({
         serverUrl: serverURL,
         logger: new NoopLogger(),
+        cancellationToken,
     })
 
     const initializationOptions = { configuration: settings }
@@ -161,9 +166,11 @@ async function registerClient(
         documentSelector,
         providerWrapper,
         featureOptions,
+        cancellationToken,
     })
 
     ctx.subscriptions.add(client)
+    ctx.subscriptions.add(() => cancellationTokenSource.cancel())
     return { client, featureOptionsSubject: featureOptions }
 }
 

--- a/shared/lsp/connection.ts
+++ b/shared/lsp/connection.ts
@@ -4,6 +4,7 @@ import { fromEvent, merge, Subject } from 'rxjs'
 import { filter, map, mapTo, take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { Logger } from './logging'
+import { CancellationToken } from '@sourcegraph/vscode-ws-jsonrpc'
 
 export interface LSPConnection extends sourcegraph.Unsubscribable {
     closed: boolean
@@ -25,9 +26,11 @@ export interface LSPConnection extends sourcegraph.Unsubscribable {
 export const webSocketTransport = ({
     serverUrl,
     logger,
+    cancellationToken,
 }: {
     serverUrl: string | URL
     logger: Logger
+    cancellationToken: CancellationToken
 }) => async (): Promise<LSPConnection> => {
     const socket = new WebSocket(serverUrl.toString())
     const event = await merge(
@@ -71,7 +74,7 @@ export const webSocketTransport = ({
             take(1)
         ),
         sendRequest: async (type, params) =>
-            connection.sendRequest(type, params),
+            connection.sendRequest(type, params, cancellationToken),
         sendNotification: async (type, params) =>
             connection.sendNotification(type, params),
         setRequestHandler: (type, handler) =>

--- a/shared/lsp/registration.ts
+++ b/shared/lsp/registration.ts
@@ -79,6 +79,7 @@ export interface RegisterOptions {
     initializationOptions?: any
     providerWrapper: ProviderWrapper
     featureOptions?: Observable<FeatureOptions>
+    cancellationToken?: lsp.CancellationToken
 }
 
 export async function register({
@@ -93,8 +94,15 @@ export async function register({
     initializationOptions,
     providerWrapper,
     featureOptions,
+    cancellationToken,
 }: RegisterOptions): Promise<LSPClient> {
     const subscriptions = new Subscription()
+
+    if (cancellationToken) {
+        cancellationToken.onCancellationRequested(() =>
+            subscriptions.unsubscribe()
+        )
+    }
 
     function syncTextDocuments(connection: LSPConnection): void {
         for (const textDocument of sourcegraph.workspace.textDocuments) {


### PR DESCRIPTION
Create a cancellation source in both Go and TypeScript extensions that expire once the extension is de-registered. This will cancel requests that are in-flight (cancelling operations such as yarn install in the TypeScript server) by unsubscribing all LSP client observers.