### PR TITLE
fix: select only candidates named by the flag

### DIFF
--- a/dev/scripts/args.ts
+++ b/dev/scripts/args.ts
@@ -9,22 +9,23 @@ export function findLanguageSpecs(): LanguageSpec[] {
         .nargs('languages', 1)
         .describe('l', 'A list of (comma-separated) languages to generate')
         .alias('l', 'languages')
-        .strict().argv as { language?: string }
+        .strict().argv as { languages?: string }
 
     const candidates = languageSpecs.filter(
         s => !blacklist.includes(s.languageID)
     )
 
-    if (!args.language) {
+    if (!args.languages) {
         return candidates
     }
 
-    return args.language.split(',').map(languageID => {
-        const spec = candidates.find(spec => spec.languageID === languageID)
-        if (!spec) {
-            throw new Error(`Unknown language ${languageID}.`)
-        }
-
-        return spec
+    // Verify that each flagged language matches a candidate, and filter the
+    // candidates to only those selected.
+    const ids = args.languages.split(',')
+    ids.map(id => {
+	if (!candidates.find(spec => spec.languageID == id)) {
+	    throw new Error(`Unknown language ${id}.`)
+	}
     })
+    return candidates.filter(spec => ids.includes(spec.languageID));
 }

--- a/dev/scripts/args.ts
+++ b/dev/scripts/args.ts
@@ -23,9 +23,9 @@ export function findLanguageSpecs(): LanguageSpec[] {
     // candidates to only those selected.
     const ids = args.languages.split(',')
     ids.map(id => {
-	if (!candidates.find(spec => spec.languageID == id)) {
-	    throw new Error(`Unknown language ${id}.`)
-	}
+        if (!candidates.find(spec => spec.languageID === id)) {
+            throw new Error(`Unknown language ${id}.`)
+        }
     })
-    return candidates.filter(spec => ids.includes(spec.languageID));
+    return candidates.filter(spec => ids.includes(spec.languageID))
 }


### PR DESCRIPTION
Previously, the check only validates that the languages named by the flag exist among the candidates. We want in addition to DROP candidates that are NOT selected by the flag, in cases where it is set.