### PR TITLE
Support product versions like 3.13.0-rc.1.

### DIFF
--- a/shared/util/versions.test.ts
+++ b/shared/util/versions.test.ts
@@ -75,6 +75,18 @@ describe('compareVersions', () => {
                 productVersion: '1.2.2-rc.1',
                 enabled: false,
             },
+            {
+                productVersion: '1.2.3+rc.1',
+                enabled: true,
+            },
+            {
+                productVersion: '1.2.4+rc.1',
+                enabled: true,
+            },
+            {
+                productVersion: '1.2.2+rc.1',
+                enabled: false,
+            },
         ]
 
         for (const test of tests) {

--- a/shared/util/versions.test.ts
+++ b/shared/util/versions.test.ts
@@ -58,6 +58,36 @@ describe('compareVersions', () => {
         }
     })
 
+    it('should compare semantic versions with rc tags', () => {
+        const tests: {
+            productVersion: string
+            enabled: boolean
+        }[] = [
+            {
+                productVersion: '1.2.3-rc.1',
+                enabled: true,
+            },
+            {
+                productVersion: '1.2.4-rc.1',
+                enabled: true,
+            },
+            {
+                productVersion: '1.2.2-rc.1',
+                enabled: false,
+            },
+        ]
+
+        for (const test of tests) {
+            const enabled = compareVersion({
+                productVersion: test.productVersion,
+                minimumDate: '',
+                minimumVersion: '1.2.3',
+            })
+
+            assert.equal(enabled, test.enabled)
+        }
+    })
+
     it('should compare build strings', () => {
         const tests: {
             productVersion: string

--- a/shared/util/versions.ts
+++ b/shared/util/versions.ts
@@ -34,7 +34,7 @@ export function compareVersion({
     }
 
     // Split any -rc.x tags from the end of the product version
-    const semanticVersion = productVersion.split('-')[0]
+    const semanticVersion = productVersion.split(/[^\d.]/)[0]
     if (semver.valid(semanticVersion)) {
         return semver.satisfies(semanticVersion, `>=${minimumVersion}`)
     }

--- a/shared/util/versions.ts
+++ b/shared/util/versions.ts
@@ -33,8 +33,10 @@ export function compareVersion({
         return enableForDev
     }
 
-    if (semver.valid(productVersion)) {
-        return semver.satisfies(productVersion, `>=${minimumVersion}`)
+    // Split any -rc.x tags from the end of the product version
+    const semanticVersion = productVersion.split('-')[0]
+    if (semver.valid(semanticVersion)) {
+        return semver.satisfies(semanticVersion, `>=${minimumVersion}`)
     }
 
     const m = productVersion.match(/^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$/)


### PR DESCRIPTION
Version comparison fails against rc tagged versions.

cc @mrnugget You may have the same bug after porting this code to src-cli.