### PR TITLE
Make flatMapConcurrent actually concurrent.

### DIFF
--- a/shared/util/ix.ts
+++ b/shared/util/ix.ts
@@ -103,8 +103,8 @@ export function flatMapConcurrent<T, R>(
         new Array<AsyncIterable<R>>(concurrency).fill(
             from(
                 of(...source).pipe(
+                    share(),
                     flatMap(asyncGeneratorFromPromise(fn)),
-                    share()
                 )
             )
         )

--- a/shared/util/ix.ts
+++ b/shared/util/ix.ts
@@ -104,7 +104,7 @@ export function flatMapConcurrent<T, R>(
             from(
                 of(...source).pipe(
                     share(),
-                    flatMap(asyncGeneratorFromPromise(fn)),
+                    flatMap(asyncGeneratorFromPromise(fn))
                 )
             )
         )


### PR DESCRIPTION
I translated `share` incorrectly when updating to ix v3: https://github.com/sourcegraph/code-intel-extensions/commit/2faf1b6fde98e4eb5421cf54e91c2695014bd4d0.

The old version wasn't actually flatMapping concurrently (as the name suggests), but flatMapping sequentially (aka flatMap).