### PR TITLE
Fix performing a search on illegal ranges.

### DIFF
--- a/shared/search/tokens.ts
+++ b/shared/search/tokens.ts
@@ -53,6 +53,10 @@ export function findSearchToken({
         }
     }
 
+    if (start >= end) {
+        return undefined
+    }
+
     const searchToken = line.substring(start, end)
 
     // Determine if the token occurs after a comment on the same line


### PR DESCRIPTION
This stops, for example, hovering over `\t` in go code.