### PR TITLE
Refactor LSP registration

### DIFF
--- a/shared/lsp/integration.test.ts
+++ b/shared/lsp/integration.test.ts
@@ -46,41 +46,6 @@ const stubTransport = (server: Record<string, (params: any) => any>) =>
     })
 
 describe('register()', () => {
-    it('should initialize one connection with each workspace folder if the server is multi-root capable', async () => {
-        const sourcegraph = createStubSourcegraphAPI()
-        sourcegraph.workspace.roots = [
-            { uri: new URL('git://repo1?rev') },
-            { uri: new URL('git://repo2?rev') },
-        ]
-        const server = {
-            initialize: sinon.spy(
-                (params: lsp.InitializeParams): lsp.InitializeResult => ({
-                    capabilities: {},
-                })
-            ),
-        }
-        const createConnection = stubTransport(server)
-        await register({
-            sourcegraph: sourcegraph as any,
-            transport: createConnection,
-            supportsWorkspaceFolders: true,
-            documentSelector: [{ language: 'foo' }],
-            logger,
-            providerWrapper,
-        })
-        sinon.assert.calledOnce(createConnection)
-        sinon.assert.calledOnce(server.initialize)
-        sinon.assert.calledWith(
-            server.initialize,
-            sinon.match({
-                rootUri: null,
-                workspaceFolders: [
-                    { name: '', uri: 'git://repo1?rev' },
-                    { name: '', uri: 'git://repo2?rev' },
-                ],
-            })
-        )
-    })
     it('should initialize one connection for each workspace folder if the server is not multi-root capable', async () => {
         const sourcegraph = createStubSourcegraphAPI()
         sourcegraph.workspace.roots = [
@@ -98,7 +63,6 @@ describe('register()', () => {
         await register({
             sourcegraph: sourcegraph as any,
             transport: createConnection,
-            supportsWorkspaceFolders: false,
             documentSelector: [{ language: 'foo' }],
             logger,
             providerWrapper,
@@ -137,7 +101,6 @@ describe('register()', () => {
         await register({
             sourcegraph: sourcegraph as any,
             transport: createConnection,
-            supportsWorkspaceFolders: false,
             documentSelector: [{ language: 'foo' }],
             logger,
             providerWrapper,

--- a/shared/lsp/registration.ts
+++ b/shared/lsp/registration.ts
@@ -386,7 +386,6 @@ export async function register({
         try {
             return await fn(connection)
         } finally {
-            connectionsByRootUri.delete(workspaceFolder.href)
             connection.unsubscribe()
         }
     }

--- a/shared/lsp/registration.ts
+++ b/shared/lsp/registration.ts
@@ -442,7 +442,11 @@ export async function register({
                                 const connection = await connectionsByRootUri.get(
                                     root.uri.toString()
                                 )
+
                                 if (connection) {
+                                    connectionsByRootUri.delete(
+                                        root.uri.toString()
+                                    )
                                     connection.unsubscribe()
                                 }
                             } catch (err) {

--- a/shared/lsp/registration.ts
+++ b/shared/lsp/registration.ts
@@ -1,5 +1,5 @@
 import { differenceBy, identity } from 'lodash'
-import { EMPTY, from, Observable, Subscription, Unsubscribable } from 'rxjs'
+import { EMPTY, from, Observable, Subscription } from 'rxjs'
 import { map, scan, startWith } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import * as uuid from 'uuid'


### PR DESCRIPTION
Remove support for multiple workspaces (we only have two language servers and neither of them support this). It's a lot of registration code that's just dead weight.

Ensure that providers are unsubscribed when we kill the underlying LSP connection. This was _actually_ (third try should finally do it) the root cause of https://github.com/sourcegraph/sourcegraph/issues/8602.

Reviewing by-commit might be easiest.