### PR TITLE
Remove cached version of queryGraphQL

### DIFF
--- a/shared/lsif/graphql.ts
+++ b/shared/lsif/graphql.ts
@@ -12,7 +12,7 @@ import { LocationConnectionNode, nodeToLocation } from './conversion'
  * relatively low unless it's a VERY popular library and LSIF data is
  * ubiquitous (which is our goal).
  */
-const MAX_REFERENCE_PAGE_REQUESTS = 20
+const MAX_REFERENCE_PAGE_REQUESTS = 5
 
 /**
  * Creates providers powered by LSIF-based code intelligence. This particular

--- a/shared/lsif/graphql.ts
+++ b/shared/lsif/graphql.ts
@@ -12,7 +12,7 @@ import { LocationConnectionNode, nodeToLocation } from './conversion'
  * relatively low unless it's a VERY popular library and LSIF data is
  * ubiquitous (which is our goal).
  */
-const MAX_REFERENCE_PAGE_REQUESTS = 5
+const MAX_REFERENCE_PAGE_REQUESTS = 10
 
 /**
  * Creates providers powered by LSIF-based code intelligence. This particular

--- a/shared/util/api.ts
+++ b/shared/util/api.ts
@@ -1,6 +1,6 @@
 import * as sourcegraph from 'sourcegraph'
 import gql from 'tagged-template-noop'
-import { rawQueryGraphQL } from './graphql'
+import { queryGraphQL } from './graphql'
 import { isDefined, sortUnique } from './helpers'
 
 /**
@@ -22,7 +22,7 @@ export async function resolveRepo(cloneURL: string): Promise<string> {
         repository: { name: string }
     }
 
-    const data = await rawQueryGraphQL<Response>(query, { cloneURL })
+    const data = await queryGraphQL<Response>(query, { cloneURL })
     return data.repository.name
 }
 
@@ -56,7 +56,7 @@ export async function resolveRev(
         }
     }
 
-    const data = await rawQueryGraphQL<Response>(query, { repoName, rev })
+    const data = await queryGraphQL<Response>(query, { repoName, rev })
     return data.repository.commit?.oid
 }
 
@@ -96,7 +96,7 @@ export async function findReposViaSearch(
         }
     }
 
-    const data = await rawQueryGraphQL<Response>(query, { query: searchQuery })
+    const data = await queryGraphQL<Response>(query, { query: searchQuery })
     return sortUnique(
         data.search.results.results.map(r => r.repository?.name)
     ).filter(isDefined)
@@ -132,7 +132,7 @@ export async function getExtensionManifests(): Promise<string[]> {
         }
     }
 
-    const data = await rawQueryGraphQL<Response>(query)
+    const data = await queryGraphQL<Response>(query)
     return data.extensionRegistry.extensions.nodes
         .map(e => e.manifest?.raw)
         .filter(isDefined)
@@ -156,7 +156,7 @@ export async function productVersion(): Promise<string> {
         }
     }
 
-    const data = await rawQueryGraphQL<Response>(query)
+    const data = await queryGraphQL<Response>(query)
     return data.site.productVersion
 }
 
@@ -178,7 +178,7 @@ export async function getUser(): Promise<string | undefined> {
         currentUser?: { id: string }
     }
 
-    const data = await rawQueryGraphQL<Response>(query)
+    const data = await queryGraphQL<Response>(query)
     return data.currentUser?.id
 }
 
@@ -211,7 +211,7 @@ export async function createAccessToken(
         }
     }
 
-    const data = await rawQueryGraphQL<Response>(query, {
+    const data = await queryGraphQL<Response>(query, {
         user,
         note,
         scopes: ['user:all'],
@@ -253,7 +253,7 @@ export async function getFileContent(
         }
     }
 
-    const data = await rawQueryGraphQL<Response>(query, { repo, rev, path })
+    const data = await queryGraphQL<Response>(query, { repo, rev, path })
     return data.repository.commit?.file?.content
 }
 
@@ -361,6 +361,6 @@ export async function search(
         }
     }
 
-    const data = await rawQueryGraphQL<Response>(query, { query: searchQuery })
+    const data = await queryGraphQL<Response>(query, { query: searchQuery })
     return data.search.results.results.filter(isDefined)
 }

--- a/shared/util/graphql.ts
+++ b/shared/util/graphql.ts
@@ -12,37 +12,13 @@ interface GraphQLResponseError {
     errors: Error[]
 }
 
-const cache = new Map<string, unknown>()
-
 /**
- * Perform a cached GraphQL query via the extension host.
+ * Perform a GraphQL query via the extension host.
  *
  * @param query The GraphQL query string.
  * @param vars The query variables.
  */
 export async function queryGraphQL<T>(
-    query: string,
-    vars: { [name: string]: unknown } = {}
-): Promise<T> {
-    const key = JSON.stringify({ query, vars })
-    const hit = cache.get(key) as T
-    if (hit) {
-        return hit
-    }
-
-    // TODO - use lru cache or something
-    const response = await rawQueryGraphQL<T>(query, vars)
-    cache.set(key, response)
-    return response
-}
-
-/**
- * Perform an uncached GraphQL query via the extension host.
- *
- * @param query The GraphQL query string.
- * @param vars The query variables.
- */
-export async function rawQueryGraphQL<T>(
     query: string,
     vars: { [name: string]: unknown } = {}
 ): Promise<T> {


### PR DESCRIPTION
We should move all caching to the provider level, not on individual requests. The only place we were caching previously was for LSIF results, but the pages for references can be large.

We aren't able to cache search results due to timeouts that were affecting large monorepo customers, so the previous caching strategy was already lacking.