### PR TITLE
Add back fix to scoped document roots

### DIFF
--- a/shared/lsp/integration.test.ts
+++ b/shared/lsp/integration.test.ts
@@ -46,7 +46,7 @@ const stubTransport = (server: Record<string, (params: any) => any>) =>
     })
 
 describe('register()', () => {
-    it('should initialize one connection for each workspace folder if the server is not multi-root capable', async () => {
+    it('should initialize one connection for each workspace folder', async () => {
         const sourcegraph = createStubSourcegraphAPI()
         sourcegraph.workspace.roots = [
             { uri: new URL('git://repo1?rev') },

--- a/shared/lsp/integration.test.ts
+++ b/shared/lsp/integration.test.ts
@@ -46,7 +46,7 @@ const stubTransport = (server: Record<string, (params: any) => any>) =>
     })
 
 describe('register()', () => {
-    it('should initialize one connection for each workspace folder', async () => {
+    it('should initialize one connection for each workspace folder if the server is not multi-root capable', async () => {
         const sourcegraph = createStubSourcegraphAPI()
         sourcegraph.workspace.roots = [
             { uri: new URL('git://repo1?rev') },
@@ -112,7 +112,7 @@ describe('register()', () => {
         sinon.assert.calledOnce(createConnection.returnValues[0].unsubscribe)
     })
     it('should register a references provider if the server reports the references capability', async () => {
-        const repoRoot = new URL('https://sourcegraph.test/repo@rev/-/raw/')
+        const repoRoot = new URL('git://sourcegraph.test/repo?rev')
         const server = {
             initialize: sinon.spy(
                 (params: lsp.InitializeParams): lsp.InitializeResult => ({
@@ -179,7 +179,7 @@ describe('register()', () => {
         assert.deepStrictEqual(selector, [
             {
                 language: 'typescript',
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                pattern: 'git://sourcegraph.test/repo?rev#**/**',
             },
         ])
         const result = await consume(
@@ -206,7 +206,7 @@ describe('register()', () => {
         ])
     })
     it('should register a definition provider if the server reports the definition capability', async () => {
-        const repoRoot = new URL('https://sourcegraph.test/repo@rev/-/raw/')
+        const repoRoot = new URL('git://host.name/author/repo?rev')
         const server = {
             initialize: sinon.spy(
                 (params: lsp.InitializeParams): lsp.InitializeResult => ({
@@ -267,7 +267,7 @@ describe('register()', () => {
         assert.deepStrictEqual(selector, [
             {
                 language: 'typescript',
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                pattern: 'git://host.name/author/repo?rev#**/**',
             },
         ])
         const result = await consume(
@@ -292,7 +292,7 @@ describe('register()', () => {
         ])
     })
     it('should register a hover provider if the server reports the hover capability', async () => {
-        const repoRoot = new URL('https://sourcegraph.test/repo@rev/-/raw/')
+        const repoRoot = new URL('git://host.name/author/repo?rev')
         const server = {
             initialize: sinon.spy(
                 async (
@@ -358,10 +358,11 @@ describe('register()', () => {
         assert.deepStrictEqual(selector, [
             {
                 language: 'typescript',
-                // IF we're in multi-connection mode, the document
+                // If the server is not multi-root capable and
+                // we're in multi-connection mode, the document
                 // selector should be scoped to the root URI
                 // of the connection that registered the provider
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                pattern: 'git://host.name/author/repo?rev#**/**',
             },
         ])
         const result = await consume(
@@ -382,7 +383,7 @@ describe('register()', () => {
     })
 
     it('should register a location provider if the server reports the implementation capability', async () => {
-        const repoRoot = new URL('https://sourcegraph.test/repo@rev/-/raw/')
+        const repoRoot = new URL('git://host.name/author/repo?rev')
         const server = {
             initialize: sinon.spy(
                 (params: lsp.InitializeParams): lsp.InitializeResult => ({
@@ -450,7 +451,7 @@ describe('register()', () => {
         assert.deepStrictEqual(selector, [
             {
                 language: 'typescript',
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                pattern: 'git://host.name/author/repo?rev#**/**',
             },
         ])
         const result = await consume(

--- a/shared/lsp/registration.test.ts
+++ b/shared/lsp/registration.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'assert'
+import { scopeDocumentSelectorToRoot } from './registration'
+
+describe('scopeDocumentSelectorToRoot()', () => {
+    it('builds selectors from clientRootUri', () => {
+        assert.deepStrictEqual(
+            scopeDocumentSelectorToRoot(
+                ['lang'],
+                new URL(
+                    'git://github.com/gorilla/mux?d83b6ffe499a29cc05fc977988d0392851779620'
+                )
+            ),
+            [
+                {
+                    language: 'lang',
+                    pattern:
+                        'git://github.com/gorilla/mux?d83b6ffe499a29cc05fc977988d0392851779620#**/**',
+                },
+            ]
+        )
+    })
+    it('builds selectors from clientRootUri and pattern', () => {
+        assert.deepStrictEqual(
+            scopeDocumentSelectorToRoot(
+                [{ pattern: '*.go' }],
+                new URL(
+                    'git://github.com/gorilla/mux?d83b6ffe499a29cc05fc977988d0392851779620'
+                )
+            ),
+            [
+                {
+                    pattern:
+                        'git://github.com/gorilla/mux?d83b6ffe499a29cc05fc977988d0392851779620#*.go',
+                },
+            ]
+        )
+    })
+})

--- a/shared/lsp/registration.ts
+++ b/shared/lsp/registration.ts
@@ -514,6 +514,9 @@ export function scopeDocumentSelectorToRoot(
             ...filter,
             // TODO filter.pattern needs to be run resolved relative to server root URI before
             // mounting on clientRootUri
-            pattern: new URL(filter.pattern ?? '**', clientRootUri).href,
+
+            // Root URIs are of the form git://repo?commit-sha, so new URL(pattern, URI) would
+            // strip the query string, resulting in a pattern that matches any commit ID.
+            pattern: `${clientRootUri.href}#${filter.pattern ?? '**/**'}`,
         }))
 }


### PR DESCRIPTION
See [slack thread](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1583487395208300) for context.

Reverting the original fix re-broke PR hovers (by showing duplicates) but fixed code intel for files in the root of a repo. This change must accompany a change in the extension host to correctly deal with these roots.