### PR TITLE
Scope DocumentSelector with baseUri

### DIFF
--- a/.buildkite/yarn-run.sh
+++ b/.buildkite/yarn-run.sh
@@ -6,6 +6,9 @@ cd $(dirname "${BASH_SOURCE[0]}")/..
 # mutex is necessary since CI runs various yarn installs in parallel
 yarn --mutex network --frozen-lockfile --network-timeout 60000
 
+# Need to build for project references
+yarn build-ts
+
 for cmd in "$@"; do
     yarn -s --cwd "${CWD:-.}" run ${cmd}
 done

--- a/dev/scripts/tsconfig.json
+++ b/dev/scripts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
+  "references": [{ "path": "../../shared" }],
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/extensions/typescript/src/xrefs.ts
+++ b/extensions/typescript/src/xrefs.ts
@@ -157,7 +157,6 @@ async function findExternalRefsInDependent(
         return []
     }
     const rootUri = new URL(
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `${repoName}@${commit}/-/raw/`,
         sourcegraphServerURL
     )

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prettier": "prettier --write --list-different '**/*.{ts,js?(on),md,yml}'",
     "prettier-check": "yarn run prettier --write=false",
     "eslint": "eslint '**/*.ts?(x)'",
+    "build-ts": "tsc -b .",
     "test": "nyc --reporter=lcov mocha '**/*.test.ts'",
     "coverage": "codecov",
     "deduplicate": "yarn-deduplicate -s fewer",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@sourcegraph/extension-api-stubs": "^0.2.4",
     "@sourcegraph/prettierrc": "^3.0.2",
     "@sourcegraph/tsconfig": "^4.0.0",
-    "@sourcegraph/tslint-config": "^13.4.0",
     "@types/fs-extra": "8.1.0",
     "@types/lodash": "4.14.149",
     "@types/lru-cache": "5.1.0",

--- a/shared/lsp/features/feature.ts
+++ b/shared/lsp/features/feature.ts
@@ -16,7 +16,7 @@ export interface Feature<
         connection: LSPConnection
         clientToServerURI: (uri: URL) => URL
         serverToClientURI: (uri: URL) => URL
-        scopedDocumentSelector: lsp.DocumentSelector
+        scopedDocumentSelector: sourcegraph.DocumentSelector
         providerWrapper: ProviderWrapper
         featureOptions: Observable<O>
     }): sourcegraph.Unsubscribable

--- a/shared/lsp/features/implementation.ts
+++ b/shared/lsp/features/implementation.ts
@@ -48,7 +48,10 @@ export const implementationFeature: Feature<
                     options.implementationId || 'unknown.impl',
                     scopedDocumentSelector,
                     {
-                        provideLocations: (textDocument, position) =>
+                        provideLocations: (
+                            textDocument: sourcegraph.TextDocument,
+                            position: sourcegraph.Position
+                        ) =>
                             observableFromAsyncIterator(
                                 implementation(textDocument, position)
                             ),

--- a/shared/lsp/integration.test.ts
+++ b/shared/lsp/integration.test.ts
@@ -180,7 +180,7 @@ describe('register()', () => {
         assert.deepStrictEqual(selector, [
             {
                 language: 'typescript',
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                baseUri: new URL('https://sourcegraph.test/repo@rev/-/raw/'),
             },
         ])
         const result = await consume(
@@ -268,7 +268,7 @@ describe('register()', () => {
         assert.deepStrictEqual(selector, [
             {
                 language: 'typescript',
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                baseUri: new URL('https://sourcegraph.test/repo@rev/-/raw/'),
             },
         ])
         const result = await consume(
@@ -364,7 +364,7 @@ describe('register()', () => {
                 // IF we're in multi-connection mode, the document
                 // selector should be scoped to the root URI
                 // of the connection that registered the provider
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                baseUri: new URL('https://sourcegraph.test/repo@rev/-/raw/'),
             },
         ])
         const result = await consume(
@@ -453,7 +453,7 @@ describe('register()', () => {
         assert.deepStrictEqual(selector, [
             {
                 language: 'typescript',
-                pattern: 'https://sourcegraph.test/repo@rev/-/raw/**',
+                baseUri: new URL('https://sourcegraph.test/repo@rev/-/raw/'),
             },
         ])
         const result = await consume(

--- a/shared/lsp/registration.ts
+++ b/shared/lsp/registration.ts
@@ -150,7 +150,7 @@ export async function register({
                 serverToClientURI,
                 clientToServerURI,
                 scopedDocumentSelector: scopeDocumentSelectorToRoot(
-                    documentSelector as lsp.DocumentSelector,
+                    documentSelector,
                     scopeRootUri
                 ),
                 providerWrapper,
@@ -500,9 +500,9 @@ function staticRegistrationsFromCapabilities(
 }
 
 export function scopeDocumentSelectorToRoot(
-    documentSelector: lsp.DocumentSelector | null,
+    documentSelector: sourcegraph.DocumentSelector | null,
     clientRootUri: URL | null
-): lsp.DocumentSelector {
+): sourcegraph.DocumentSelector {
     if (!documentSelector || documentSelector.length === 0) {
         documentSelector = [{ pattern: '**' }]
     }
@@ -511,13 +511,8 @@ export function scopeDocumentSelectorToRoot(
     }
     return documentSelector
         .map(
-            (filter): lsp.DocumentFilter =>
+            (filter): sourcegraph.DocumentFilter =>
                 typeof filter === 'string' ? { language: filter } : filter
         )
-        .map(filter => ({
-            ...filter,
-            // TODO filter.pattern needs to be run resolved relative to server root URI before
-            // mounting on clientRootUri
-            pattern: new URL(filter.pattern ?? '**', clientRootUri).href,
-        }))
+        .map(filter => ({ ...filter, baseUri: clientRootUri }))
 }

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs'
+import { NEVER, Observable } from 'rxjs'
 import { shareReplay } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { impreciseBadge } from './badges'
@@ -63,9 +63,7 @@ export class NoopProviderWrapper implements ProviderWrapper {
             doc: sourcegraph.TextDocument,
             pos: sourcegraph.Position
         ) =>
-            provider
-                ? observableFromAsyncIterator(provider(doc, pos))
-                : new Observable(),
+            provider ? observableFromAsyncIterator(provider(doc, pos)) : NEVER,
     })
 
     public references = (
@@ -78,7 +76,7 @@ export class NoopProviderWrapper implements ProviderWrapper {
         ) =>
             provider
                 ? observableFromAsyncIterator(provider(doc, pos, ctx))
-                : new Observable(),
+                : NEVER,
     })
 
     public hover = (provider?: HoverProvider): sourcegraph.HoverProvider => ({
@@ -86,9 +84,7 @@ export class NoopProviderWrapper implements ProviderWrapper {
             doc: sourcegraph.TextDocument,
             pos: sourcegraph.Position
         ) =>
-            provider
-                ? observableFromAsyncIterator(provider(doc, pos))
-                : new Observable(),
+            provider ? observableFromAsyncIterator(provider(doc, pos)) : NEVER,
     })
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "composite": true,
     "rootDir": ".",
     "allowSyntheticDefaultImports": true
-  }
+  },
+  "include": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,16 +938,6 @@
   resolved "https://registry.yarnpkg.com/@sourcegraph/tsconfig/-/tsconfig-4.0.0.tgz#dd2a406f90760bb789fd89fde4bd0a8d681f2767"
   integrity sha512-jxrhKbek4yu1HUDpUhqR9hAGFiUgaJ9NIM+c8JEkAnvpW67ab1AUFWb82aSVfZWX1UVqfR84AMr7xP3E8LlL+A==
 
-"@sourcegraph/tslint-config@^13.4.0":
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/tslint-config/-/tslint-config-13.4.0.tgz#946f82eb464d66190caf6d9dc5e9e473e2de2fe9"
-  integrity sha512-Uci+0uZ/6ztsBA4m9nYVNsdbCtcphJatU7xi8a4aLtdqVyceSgl8HicUbesKYUmriBUbcX+XTZB0LJxXYD2fRA==
-  dependencies:
-    rxjs-tslint-rules "^4.23.0"
-    tslint-config-prettier "^1.18.0"
-    tslint-react "^4.0.0"
-    tslint-react-hooks "^2.1.0"
-
 "@sourcegraph/typescript-language-server@^0.3.7-fork":
   version "0.3.7-fork"
   resolved "https://registry.yarnpkg.com/@sourcegraph/typescript-language-server/-/typescript-language-server-0.3.7-fork.tgz#10dbd707be6da80ddb5c0e3c5c1205057aeca796"
@@ -2421,13 +2411,6 @@ decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
-
-decamelize@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-3.2.0.tgz#84b8e8f4f8c579f938e35e2cc7024907e0090851"
-  integrity sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==
-  dependencies:
-    xregexp "^4.2.4"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -6535,19 +6518,6 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rxjs-tslint-rules@^4.23.0:
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/rxjs-tslint-rules/-/rxjs-tslint-rules-4.28.1.tgz#4440403e8bee87e67a367a6ee1d7b4bde96dd35a"
-  integrity sha512-j76YWbtC4lExSjT1DaMvI8eMnwKGIK5na3lfghx70wwj2oH3PWZm9DzKrza1+GK/w4pyINPlBNX0eeFVpjHDTg==
-  dependencies:
-    "@phenomnomnominal/tsquery" "^4.0.0"
-    decamelize "^3.0.0"
-    resolve "^1.4.0"
-    semver "^7.0.0"
-    tslib "^1.8.0"
-    tsutils "^3.0.0"
-    tsutils-etc "^1.1.0"
-
 rxjs@^6.5.1, rxjs@^6.5.3, rxjs@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
@@ -6594,7 +6564,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.1.3, semver@^7.0.0, semver@^7.1.3:
+semver@7.1.3, semver@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
@@ -6822,7 +6792,7 @@ source-map@^0.5.0, source-map@^0.5.6:
 
 sourcegraph@^23.1.0, sourcegraph@^23.2.0:
   version "23.2.0"
-  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-23.2.0.tgz#e5e715760fc12b0672843764a8a7913e45a7dfa2"
+  resolved "https://registry.npmjs.org/sourcegraph/-/sourcegraph-23.2.0.tgz#e5e715760fc12b0672843764a8a7913e45a7dfa2"
   integrity sha512-BL9lkjqAKumAn+T21zI5+Jikkj7mt84UW/aAFo2ySc/Ork1RsAeli+Jy8IQO/XCO71NYoRYXRkaqIdErq0xh4Q==
 
 spawn-wrap@^2.0.0:
@@ -7419,11 +7389,6 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslint-config-prettier@^1.18.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
-  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-
 tslint-etc@^1.6.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslint-etc/-/tslint-etc-1.10.0.tgz#de264c4d8042c0eb5627d4c09a60089aa3a65e8e"
@@ -7434,24 +7399,12 @@ tslint-etc@^1.6.0:
     tsutils "^3.0.0"
     tsutils-etc "^1.0.0"
 
-tslint-react-hooks@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tslint-react-hooks/-/tslint-react-hooks-2.2.1.tgz#c52c7df65ee1517b2d6c92bc716e9ef72ccdf208"
-  integrity sha512-bqIg2uZe+quJMfSOGc4OOZ4awo6TP1ejGDGS6IKg2WIrS0XnWfhUJ99i3B8rUpnZhuD4vRSvyYIbXPUmEqQxxQ==
-
-tslint-react@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-4.2.0.tgz#41b16e0438365f8d3ed4120501f02cabff9fd1e4"
-  integrity sha512-lO22+FKr9ZZGueGiuALzvZE/8ANoDoCHGCknX1Ge3ALrfcLQHQ1VGdyb1scZXQFdEQEfwBTIU40r5BUlJpn0JA==
-  dependencies:
-    tsutils "^3.9.1"
-
-tsutils-etc@^1.0.0, tsutils-etc@^1.1.0:
+tsutils-etc@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tsutils-etc/-/tsutils-etc-1.1.0.tgz#82ce1c92da29e07d3cde95692d5c5e8dbdc92fd0"
   integrity sha512-pJlLtLmQPUyGHqY/Pq6EGnpGmQCnnTDZetQ7eWkeQ5xaw4GtfcR1Zt7HMKFHGDDp53HzQfbqQ+7ps6iJbfa9Hw==
 
-tsutils@^3.0.0, tsutils@^3.17.1, tsutils@^3.9.1:
+tsutils@^3.0.0, tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
@@ -7942,7 +7895,7 @@ xmlchars@^2.1.1:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xregexp@^4.2.4, xregexp@^4.3.0:
+xregexp@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.3.0.tgz#7e92e73d9174a99a59743f67a4ce879a04b5ae50"
   integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==


### PR DESCRIPTION
This is a proper fix for both https://github.com/sourcegraph/sourcegraph/issues/8602 and broken codeintel for root files ([Slack thread](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1583444612193300?thread_ts=1583444599.193000&cid=CHXHX7XAS)).
Codeintel extensions need to be able to scope providers to workspace roots. Doing so in `pattern` does not work, because `minimatch` is not built for working with URIs (in particular it broke for files in the root).

Instead, uses the new `baseUri` introduced in https://github.com/sourcegraph/sourcegraph/pull/8858.

Closes https://github.com/sourcegraph/code-intel-extensions/pull/295.
Fixes sourcegraph/sourcegraph#8602.