### PR TITLE
Add options to include forks and archives in search

### DIFF
--- a/extensions/go/README.md
+++ b/extensions/go/README.md
@@ -35,6 +35,15 @@ This extension comes with built-in code intelligence provided by [search-based h
 
 These heuristics work well for tokens with unique names, such as `render_to_view` or `TLSConfig`. They do not work well for ambiguous tokens, such as `open` or `file`.
 
+### Indexed and archived repositories
+
+To include indexed and/or archived repositories in search results, add the following to your Sourcegraph global settings:
+
+```json
+  "basicCodeIntel.includeForks": true,
+  "basicCodeIntel.includeArchives": true
+```
+
 ### Large repositories
 
 Basic code intelligence will perform a search query in the commit you are viewing. This may cause performance issues if the commit is not indexed and the repository is large. After a timeout period with no results, an index-only search will be performed. This type of query may return results for a commit other than the one you are currently viewing. The default timeout period is five seconds, but can be lowered by adding the following to your Sourcegraph global settings (units are milliseconds):

--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -80,8 +80,12 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
           "type": "boolean"
         },
-        "basicCodeIntel.debug.traceSearch": {
-          "description": "Trace Sourcegraph search API requests in the console.",
+        "basicCodeIntel.includeForks": {
+          "description": "Whether to include forked repositories in search results.",
+          "type": "boolean"
+        },
+        "basicCodeIntel.includeArchives": {
+          "description": "Whether to include archived repositories in search results.",
           "type": "boolean"
         },
         "basicCodeIntel.indexOnly": {

--- a/extensions/go/src/settings.ts
+++ b/extensions/go/src/settings.ts
@@ -11,9 +11,13 @@ export interface Settings {
      */
     'codeIntel.lsif'?: boolean
     /**
-     * Trace Sourcegraph search API requests in the console.
+     * Whether to include forked repositories in search results.
      */
-    'basicCodeIntel.debug.traceSearch'?: boolean
+    'basicCodeIntel.includeForks'?: boolean
+    /**
+     * Whether to include archived repositories in search results.
+     */
+    'basicCodeIntel.includeArchives'?: boolean
     /**
      * Whether to use only indexed requests to the search API.
      */

--- a/extensions/template/README.md
+++ b/extensions/template/README.md
@@ -37,6 +37,15 @@ This extension comes with built-in code intelligence provided by [search-based h
 
 These heuristics work well for tokens with unique names, such as `render_to_view` or `TLSConfig`. They do not work well for ambiguous tokens, such as `open` or `file`.
 
+### Indexed and archived repositories
+
+To include indexed and/or archived repositories in search results, add the following to your Sourcegraph global settings:
+
+```json
+  "basicCodeIntel.includeForks": true,
+  "basicCodeIntel.includeArchives": true
+```
+
 ### Large repositories
 
 Basic code intelligence will perform a search query in the commit you are viewing. This may cause performance issues if the commit is not indexed and the repository is large. After a timeout period with no results, an index-only search will be performed. This type of query may return results for a commit other than the one you are currently viewing. The default timeout period is five seconds, but can be lowered by adding the following to your Sourcegraph global settings (units are milliseconds):

--- a/extensions/template/package.json
+++ b/extensions/template/package.json
@@ -50,8 +50,12 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
           "type": "boolean"
         },
-        "basicCodeIntel.debug.traceSearch": {
-          "description": "Trace Sourcegraph search API requests in the console.",
+        "basicCodeIntel.includeForks": {
+          "description": "Whether to include forked repositories in search results.",
+          "type": "boolean"
+        },
+        "basicCodeIntel.includeArchives": {
+          "description": "Whether to include archived repositories in search results.",
           "type": "boolean"
         },
         "basicCodeIntel.indexOnly": {

--- a/extensions/typescript/README.md
+++ b/extensions/typescript/README.md
@@ -35,6 +35,15 @@ This extension comes with built-in code intelligence provided by [search-based h
 
 These heuristics work well for tokens with unique names, such as `render_to_view` or `TLSConfig`. They do not work well for ambiguous tokens, such as `open` or `file`.
 
+### Indexed and archived repositories
+
+To include indexed and/or archived repositories in search results, add the following to your Sourcegraph global settings:
+
+```json
+  "basicCodeIntel.includeForks": true,
+  "basicCodeIntel.includeArchives": true
+```
+
 ### Large repositories
 
 Basic code intelligence will perform a search query in the commit you are viewing. This may cause performance issues if the commit is not indexed and the repository is large. After a timeout period with no results, an index-only search will be performed. This type of query may return results for a commit other than the one you are currently viewing. The default timeout period is five seconds, but can be lowered by adding the following to your Sourcegraph global settings (units are milliseconds):

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -84,8 +84,12 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
           "type": "boolean"
         },
-        "basicCodeIntel.debug.traceSearch": {
-          "description": "Trace Sourcegraph search API requests in the console.",
+        "basicCodeIntel.includeForks": {
+          "description": "Whether to include forked repositories in search results.",
+          "type": "boolean"
+        },
+        "basicCodeIntel.includeArchives": {
+          "description": "Whether to include archived repositories in search results.",
           "type": "boolean"
         },
         "basicCodeIntel.indexOnly": {

--- a/extensions/typescript/src/settings.ts
+++ b/extensions/typescript/src/settings.ts
@@ -11,9 +11,13 @@ export interface Settings {
      */
     'codeIntel.lsif'?: boolean
     /**
-     * Trace Sourcegraph search API requests in the console.
+     * Whether to include forked repositories in search results.
      */
-    'basicCodeIntel.debug.traceSearch'?: boolean
+    'basicCodeIntel.includeForks'?: boolean
+    /**
+     * Whether to include archived repositories in search results.
+     */
+    'basicCodeIntel.includeArchives'?: boolean
     /**
      * Whether to use only indexed requests to the search API.
      */

--- a/shared/search/config.ts
+++ b/shared/search/config.ts
@@ -1,0 +1,11 @@
+import * as sourcegraph from 'sourcegraph'
+import { BasicCodeIntelligenceSettings } from './settings'
+
+/** Retrieves a config value by key. */
+export function getConfig<T>(key: string, defaultValue: T): T {
+    const configuredValue = sourcegraph.configuration
+        .get<BasicCodeIntelligenceSettings>()
+        .get(key)
+
+    return configuredValue || defaultValue
+}

--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -373,8 +373,6 @@ async function searchReferences(
  * @param search The search function.
  * @param args The arguments to the search function.
  * @param negateRepoFilter Whether to look only inside or outside the given repo.
- * @param includeForks Whether to include forked repos in results.
- * @param includeArchived Whether to include archived repos in results.
  */
 export function searchWithFallback<
     P extends { repo: string; commit: string; queryTerms: string[] },
@@ -457,7 +455,6 @@ function searchUnindexed<
 /**
  * Perform a search query.
  *
- *
  * @param api The GraphQL API instance.
  * @param queryTerms The terms of the search query.
  */
@@ -537,7 +534,6 @@ function isSourcegraphDotCom(): boolean {
         sourcegraph.internal.sourcegraphURL.href === 'https://sourcegraph.com/'
     )
 }
-
 
 /**
  * Race an in-flight promise and a promise that will be invoked only after

--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -11,8 +11,8 @@ import { Result, resultToLocation, searchResultToResults } from './conversion'
 import { findDocstring } from './docstrings'
 import { wrapIndentationInCodeBlocks } from './markdown'
 import { definitionQuery, referencesQuery } from './queries'
-import { BasicCodeIntelligenceSettings } from './settings'
 import { findSearchToken } from './tokens'
+import { getConfig } from './config'
 
 /** The number of elements in the definition LRU cache. */
 const DEFINITION_CACHE_SIZE = 50
@@ -538,14 +538,6 @@ function isSourcegraphDotCom(): boolean {
     )
 }
 
-/** Retrieves a config value by key. */
-function getConfig<T>(key: string, defaultValue: T): T {
-    const configuredValue = sourcegraph.configuration
-        .get<BasicCodeIntelligenceSettings>()
-        .get(key)
-
-    return configuredValue || defaultValue
-}
 
 /**
  * Race an in-flight promise and a promise that will be invoked only after

--- a/shared/search/queries.test.ts
+++ b/shared/search/queries.test.ts
@@ -7,7 +7,7 @@ describe('search requests', () => {
     it('makes correct search requests for goto definition', () => {
         interface DefinitionTest {
             doc: sourcegraph.TextDocument
-            expectedSearchQuery: string
+            expectedSearchQueryTerms: string[]
         }
         const tests: DefinitionTest[] = [
             {
@@ -16,8 +16,13 @@ describe('search requests', () => {
                     languageId: 'cpp',
                     text: 'token',
                 }),
-                expectedSearchQuery:
-                    '^token$ type:symbol patternType:regexp case:yes file:\\.(cpp)$',
+                expectedSearchQueryTerms: [
+                    '^token$',
+                    'type:symbol',
+                    'patternType:regexp',
+                    'case:yes',
+                    'file:\\.(cpp)$',
+                ],
             },
         ]
 
@@ -28,7 +33,7 @@ describe('search requests', () => {
                     doc: test.doc,
                     fileExts: ['cpp'],
                 }),
-                test.expectedSearchQuery
+                test.expectedSearchQueryTerms
             )
         }
     })
@@ -36,7 +41,7 @@ describe('search requests', () => {
     it('makes correct search requests for references', () => {
         interface ReferencesTest {
             doc: sourcegraph.TextDocument
-            expectedSearchQuery: string
+            expectedSearchQueryTerms: string[]
         }
         const tests: ReferencesTest[] = [
             {
@@ -45,8 +50,13 @@ describe('search requests', () => {
                     languageId: 'cpp',
                     text: 'token',
                 }),
-                expectedSearchQuery:
-                    '\\btoken\\b type:file patternType:regexp case:yes file:\\.(cpp)$',
+                expectedSearchQueryTerms: [
+                    '\\btoken\\b',
+                    'type:file',
+                    'patternType:regexp',
+                    'case:yes',
+                    'file:\\.(cpp)$',
+                ],
             },
         ]
 
@@ -57,7 +67,7 @@ describe('search requests', () => {
                     doc: test.doc,
                     fileExts: ['cpp'],
                 }),
-                test.expectedSearchQuery
+                test.expectedSearchQueryTerms
             )
         }
     })

--- a/shared/search/queries.ts
+++ b/shared/search/queries.ts
@@ -12,13 +12,13 @@ export function definitionQuery({
     doc,
     fileExts,
 }: {
-    /** The search term. */
+    /** The search token text. */
     searchToken: string
     /** The current text document. */
     doc: sourcegraph.TextDocument
     /** File extensions used by the current extension. */
     fileExts: string[]
-}): string {
+}): string[] {
     const { path } = parseGitURI(new URL(doc.uri))
 
     return [
@@ -27,7 +27,7 @@ export function definitionQuery({
         'patternType:regexp',
         'case:yes',
         fileExtensionTerm(path, fileExts),
-    ].join(' ')
+    ]
 }
 
 /**
@@ -40,13 +40,13 @@ export function referencesQuery({
     doc,
     fileExts,
 }: {
-    /** The search term. */
+    /** The search token text. */
     searchToken: string
     /** The current text document. */
     doc: sourcegraph.TextDocument
     /** File extensions used by the current extension. */
     fileExts: string[]
-}): string {
+}): string[] {
     const { path } = parseGitURI(new URL(doc.uri))
 
     return [
@@ -55,7 +55,7 @@ export function referencesQuery({
         'patternType:regexp',
         'case:yes',
         fileExtensionTerm(path, fileExts),
-    ].join(' ')
+    ]
 }
 
 const blacklist = ['thrift', 'proto', 'graphql']

--- a/shared/search/queries.ts
+++ b/shared/search/queries.ts
@@ -1,6 +1,7 @@
 import { extname } from 'path'
 import * as sourcegraph from 'sourcegraph'
 import { parseGitURI } from '../util/uri'
+import { getConfig } from './config'
 
 /**
  * Create a search query to find definitions of a symbol.
@@ -21,13 +22,13 @@ export function definitionQuery({
 }): string[] {
     const { path } = parseGitURI(new URL(doc.uri))
 
-    return [
+    return addRepositoryKindTerms([
         `^${searchToken}$`,
         'type:symbol',
         'patternType:regexp',
         'case:yes',
         fileExtensionTerm(path, fileExts),
-    ]
+    ])
 }
 
 /**
@@ -49,13 +50,30 @@ export function referencesQuery({
 }): string[] {
     const { path } = parseGitURI(new URL(doc.uri))
 
-    return [
+    return addRepositoryKindTerms([
         `\\b${searchToken}\\b`,
         'type:file',
         'patternType:regexp',
         'case:yes',
         fileExtensionTerm(path, fileExts),
-    ]
+    ])
+}
+
+/**
+ * Adds options to include forked and archived repositories.
+ *
+ * @param queryTerms The terms of the search query.
+ */
+function addRepositoryKindTerms(queryTerms: string[]): string[] {
+    if (getConfig('basicCodeIntel.includeForks', false)) {
+        queryTerms.push('fork:yes')
+    }
+
+    if (getConfig('basicCodeIntel.includeArchives', false)) {
+        queryTerms.push('archived:yes')
+    }
+
+    return queryTerms
 }
 
 const blacklist = ['thrift', 'proto', 'graphql']

--- a/shared/search/settings.ts
+++ b/shared/search/settings.ts
@@ -11,9 +11,13 @@ export interface BasicCodeIntelligenceSettings {
      */
     'codeIntel.lsif'?: boolean
     /**
-     * Trace Sourcegraph search API requests in the console.
+     * Whether to include forked repositories in search results.
      */
-    'basicCodeIntel.debug.traceSearch'?: boolean
+    'basicCodeIntel.includeForks'?: boolean
+    /**
+     * Whether to include archived repositories in search results.
+     */
+    'basicCodeIntel.includeArchives'?: boolean
     /**
      * Whether to use only indexed requests to the search API.
      */


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/8739 changed the default behavior of search to exclude forked and archived repositories. This caused a regression in the code intel test suite as many of the test repositories (in the sourcegraph-testing org) are forked from a public source.

This PR adds options to enable searching in forked and archived repositories for code intel.