### PR TITLE
Do not emit event on empty definition result set

### DIFF
--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -163,7 +163,18 @@ export function createDefinitionProvider(
 
             if (lspProvider) {
                 for await (const lspResult of lspProvider(doc, pos)) {
-                    await emitter.emitOnce('lspDefinitions')
+                    const nonEmptyResult =
+                        lspResult &&
+                        !(Array.isArray(lspResult) && lspResult.length === 0)
+
+                    if (nonEmptyResult) {
+                        // Do not emit definition events for empty location arrays
+                        await emitter.emitOnce('lspDefinitions')
+                    }
+
+                    // Always emit the result regardless if it's interesting. If we return
+                    // without emitting anything here we may indefinitely show an empty hover
+                    // on identifiers with no interesting data indefinitely.
                     yield lspResult
                 }
 


### PR DESCRIPTION
This stops us from emitting events on trivial definitions (e.g. requests for non-symbol positions in the UI).

Context: [slack thread](https://sourcegraph.slack.com/archives/CN4FC7XT4/p1584986913127400?thread_ts=1584986498.126000&cid=CN4FC7XT4). We had 65k lspDefinitions events but only 18k hover events. Obviously we are sending more lspDefinition events than hovers, even though lspDefinitions should not exceed hovers.

It turns out we don't show a hover for empty location sets, but we are still emitting the event when we get back an empty location set from the language server. This happens particularly when someone mouses over a position in the that looks like a symbol from the UI's point of view, but isn't really anything from the lang server's point of view (maybe an identifier-like token in a string or comment).

This will stop sending non-interesting results on lspDefinition. LSP references and hovers are already guarded, as are all LSIF results. This was the odd-one-out.