### PR TITLE
Search forks within fork

### DIFF
--- a/extensions/go/src/gddo.test.ts
+++ b/extensions/go/src/gddo.test.ts
@@ -10,7 +10,11 @@ import { API } from '../../../shared/util/api'
 
 describe('findReposViaGDDO', () => {
     const trimGitHubPrefix = (url: string) =>
-        Promise.resolve(url.substring('github.com/'.length))
+        Promise.resolve({
+            name: url.substring('github.com/'.length),
+            isFork: false,
+            isArchived: false,
+        })
 
     const makeStubAPI = () => {
         const api = new API()

--- a/extensions/go/src/gddo.ts
+++ b/extensions/go/src/gddo.ts
@@ -36,14 +36,16 @@ export async function findReposViaGDDO(
     const url = new URL((corsAnywhereURL || '') + importersURL.href)
 
     return sortUnique(
-        await Promise.all(
-            (await fetcher(url)).results
-                .map(({ path }) => path)
-                .map(transformGithubCloneURL)
-                .filter(isDefined)
-                .slice(0, limit)
-                .map(safePromise(api.resolveRepo.bind(api)))
-        )
+        (
+            await Promise.all(
+                (await fetcher(url)).results
+                    .map(({ path }) => path)
+                    .map(transformGithubCloneURL)
+                    .filter(isDefined)
+                    .slice(0, limit)
+                    .map(safePromise(api.resolveRepo.bind(api)))
+            )
+        ).map(meta => meta?.name)
     ).filter(isDefined)
 }
 

--- a/extensions/typescript/src/package.test.ts
+++ b/extensions/typescript/src/package.test.ts
@@ -7,7 +7,9 @@ describe('resolvePackageRepo', () => {
     it('resolves string repo', async () => {
         const api = new API()
         const mock = sinon.stub(api, 'resolveRepo')
-        mock.callsFake(repo => Promise.resolve(repo))
+        mock.callsFake(repo =>
+            Promise.resolve({ name: repo, isFork: false, isArchived: false })
+        )
         const name = await resolvePackageRepo('{"repository": "foo"}', api)
         assert.equal(name, 'foo')
         sinon.assert.calledWith(mock, 'foo')
@@ -16,7 +18,9 @@ describe('resolvePackageRepo', () => {
     it('resolves repos with url', async () => {
         const api = new API()
         const mock = sinon.stub(api, 'resolveRepo')
-        mock.callsFake(repo => Promise.resolve(repo))
+        mock.callsFake(repo =>
+            Promise.resolve({ name: repo, isFork: false, isArchived: false })
+        )
         const name = await resolvePackageRepo(
             '{"repository": {"url": "foo"}}',
             api
@@ -28,7 +32,9 @@ describe('resolvePackageRepo', () => {
     it('resolves repos without repo field', async () => {
         const api = new API()
         const mock = sinon.stub(api, 'resolveRepo')
-        mock.callsFake(repo => Promise.resolve(repo))
+        mock.callsFake(repo =>
+            Promise.resolve({ name: repo, isFork: false, isArchived: false })
+        )
         const name = await resolvePackageRepo('{}', api)
         assert.equal(name, undefined)
         sinon.assert.notCalled(mock)

--- a/extensions/typescript/src/package.ts
+++ b/extensions/typescript/src/package.ts
@@ -13,7 +13,7 @@ export interface PackageJson {
  * @param rawManifest The unparsed manifest.
  * @param api The GraphQL API instance.
  */
-export function resolvePackageRepo(
+export async function resolvePackageRepo(
     rawManifest: string,
     api: API = new API()
 ): Promise<string | undefined> {
@@ -22,11 +22,13 @@ export function resolvePackageRepo(
         return Promise.resolve(undefined)
     }
 
-    return safePromise(api.resolveRepo.bind(api))(
-        typeof packageJson.repository === 'string'
-            ? packageJson.repository
-            : packageJson.repository.url
-    )
+    return (
+        await safePromise(api.resolveRepo.bind(api))(
+            typeof packageJson.repository === 'string'
+                ? packageJson.repository
+                : packageJson.repository.url
+        )
+    )?.name
 }
 
 function definitelyTypedPackageName(uri: URL): string | undefined {

--- a/shared/search/providers.test.ts
+++ b/shared/search/providers.test.ts
@@ -115,9 +115,19 @@ describe('search providers', () => {
         tick++
     })
 
+    const newAPIWithStubResolveRepo = (): API => {
+        const api = new API()
+        const stub = sinon.stub(api, 'resolveRepo')
+        stub.callsFake(repo =>
+            Promise.resolve({ name: repo, isFork: false, isArchived: false })
+        )
+
+        return api
+    }
+
     describe('definition provider', () => {
         it('should correctly parse result', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const stub = sinon.stub(api, 'search')
             stub.resolves([searchResult1])
 
@@ -149,7 +159,7 @@ describe('search providers', () => {
         })
 
         it('should fallback to remote definition', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const stub = sinon.stub(api, 'search')
             stub.callsFake((searchQuery: string) =>
                 Promise.resolve(
@@ -192,7 +202,7 @@ describe('search providers', () => {
         })
 
         it('should apply definition filter', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const stub = sinon.stub(api, 'search')
             stub.resolves([searchResult1, searchResult2, searchResult3])
 
@@ -221,7 +231,7 @@ describe('search providers', () => {
         })
 
         it('should fallback to index-only queries', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const stub = sinon.stub(api, 'search')
             stub.callsFake(
                 (searchQuery: string): Promise<SearchResult[]> =>
@@ -265,7 +275,7 @@ describe('search providers', () => {
         })
 
         it('should fallback to index-only remote definition definition', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const stub = sinon.stub(api, 'search')
             stub.callsFake(
                 (searchQuery: string): Promise<SearchResult[]> =>
@@ -321,7 +331,7 @@ describe('search providers', () => {
 
     describe('references provider', () => {
         it('should correctly parse result', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const stub = sinon.stub(api, 'search')
             stub.callsFake((searchQuery: string) =>
                 Promise.resolve(
@@ -371,7 +381,7 @@ describe('search providers', () => {
         })
 
         it('should fallback to index-only queries', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const stub = sinon.stub(api, 'search')
 
             stub.callsFake(
@@ -458,7 +468,7 @@ describe('search providers', () => {
 
     describe('hover provider', () => {
         it('should correctly parse result', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const searchStub = sinon.stub(api, 'search')
             searchStub.resolves([searchResult1])
             const getFileContentStub = sinon.stub(api, 'getFileContent')
@@ -500,7 +510,7 @@ describe('search providers', () => {
         })
 
         it('should fallback to index-only queries', async () => {
-            const api = new API()
+            const api = newAPIWithStubResolveRepo()
             const searchStub = sinon.stub(api, 'search')
             searchStub.callsFake((searchQuery: string) =>
                 searchQuery.includes('index:only')

--- a/shared/search/providers.test.ts
+++ b/shared/search/providers.test.ts
@@ -121,7 +121,7 @@ describe('search providers', () => {
     }: {
         isFork?: boolean
         isArchived?: boolean
-    }={}): API => {
+    } = {}): API => {
         const api = new API()
         const stub = sinon.stub(api, 'resolveRepo')
         stub.callsFake(repo =>
@@ -334,7 +334,7 @@ describe('search providers', () => {
         })
 
         it('should search forks in same repo if repo is a fork', async () => {
-            const api = newAPIWithStubResolveRepo({isFork:true})
+            const api = newAPIWithStubResolveRepo({ isFork: true })
             const stub = sinon.stub(api, 'search')
             stub.callsFake((searchQuery: string) =>
                 Promise.resolve(
@@ -497,23 +497,8 @@ describe('search providers', () => {
             ])
         })
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
         it('should search forks in same repo if repo is a fork', async () => {
-            const api = newAPIWithStubResolveRepo({isFork:true})
+            const api = newAPIWithStubResolveRepo({ isFork: true })
             const stub = sinon.stub(api, 'search')
 
             stub.callsFake(

--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -4,7 +4,7 @@ import { take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { FilterDefinitions, LanguageSpec } from '../language-specs/spec'
 import { Providers, SourcegraphProviders } from '../providers'
-import { API } from '../util/api'
+import { API, RepoMeta } from '../util/api'
 import { asArray, isDefined } from '../util/helpers'
 import { asyncGeneratorFromPromise } from '../util/ix'
 import { parseGitURI } from '../util/uri'
@@ -33,6 +33,21 @@ export function createProviders(
     wrappedProviders: Partial<SourcegraphProviders>,
     api: API = new API()
 ): Providers {
+    /** Small never-evict map from repo names to their meta. */
+    const cachedMetas = new Map<string, Promise<RepoMeta>>()
+
+    /** Retrieves the name and fork/archive status of a repository. */
+    const resolveRepo = (name: string): Promise<RepoMeta> => {
+        const cachedMeta = cachedMetas.get(name)
+        if (cachedMeta !== undefined) {
+            return cachedMeta
+        }
+
+        const meta = api.resolveRepo(name)
+        cachedMetas.set(name, meta)
+        return meta
+    }
+
     /**
      * Retrieve the text of the current text document. This may be cached on the
      * text document itself. If it's not, we fetch it from the Raw API.
@@ -102,12 +117,15 @@ export function createProviders(
         }
         const { text, searchToken } = contentAndToken
         const { repo, commit, path } = parseGitURI(new URL(doc.uri))
+        const { isFork, isArchived } = await resolveRepo(repo)
 
         // Construct base definition query without scoping terms
         const queryTerms = definitionQuery({ searchToken, doc, fileExts })
         const queryArgs = {
             doc,
             repo,
+            isFork,
+            isArchived,
             commit,
             path,
             text,
@@ -156,11 +174,14 @@ export function createProviders(
         }
         const { searchToken } = contentAndToken
         const { repo, commit } = parseGitURI(new URL(doc.uri))
+        const { isFork, isArchived } = await resolveRepo(repo)
 
         // Construct base references query without scoping terms
         const queryTerms = referencesQuery({ searchToken, doc, fileExts })
         const queryArgs = {
             repo,
+            isFork,
+            isArchived,
             commit,
             queryTerms,
         }
@@ -301,6 +322,10 @@ async function searchAndFilterDefinitions(
         doc: sourcegraph.TextDocument
         /** The repository containing the current text document. */
         repo: string
+        /** Whether the repository containing the current text document is a fork. */
+        isFork: boolean
+        /** Whether the repository containing the current text document is archived. */
+        isArchived: boolean
         /** The path of the current text document. */
         path: string
         /** The content of the current text document */
@@ -369,7 +394,13 @@ async function searchReferences(
  * @param negateRepoFilter Whether to look only inside or outside the given repo.
  */
 export function searchWithFallback<
-    P extends { repo: string; commit: string; queryTerms: string[] },
+    P extends {
+        repo: string
+        isFork: boolean
+        isArchived: boolean
+        commit: string
+        queryTerms: string[]
+    },
     R
 >(
     search: (args: P) => Promise<R>,
@@ -395,25 +426,40 @@ export function searchWithFallback<
  * @param negateRepoFilter Whether to look only inside or outside the given repo.
  */
 function searchIndexed<
-    P extends { repo: string; commit: string; queryTerms: string[] },
+    P extends {
+        repo: string
+        isFork: boolean
+        isArchived: boolean
+        commit: string
+        queryTerms: string[]
+    },
     R
 >(
     search: (args: P) => Promise<R>,
     args: P,
     negateRepoFilter = false
 ): Promise<R> {
-    const { repo, queryTerms } = args
+    const { repo, isFork, isArchived, queryTerms } = args
 
     // Create a copy of the args so that concurrent calls to other
     // search methods do not have their query terms unintentionally
     // modified.
-    const queryTermsCopy = Array.from(queryTerms)
+    let queryTermsCopy = Array.from(queryTerms)
 
     // Unlike unindexed search, we can't supply a commit as that particular
     // commit may not be indexed. We force index and look inside/outside
     // the repo at _whatever_ commit happens to be indexed at the time.
     queryTermsCopy.push((negateRepoFilter ? '-' : '') + `repo:^${repo}$`)
     queryTermsCopy.push('index:only')
+
+    // If we're a fork, search in forks _for the same repo_. Otherwise,
+    // search in forks only if it's set in the settings. This is also
+    // symmetric for archived repositories.
+    queryTermsCopy = addRepositoryKindTerms(
+        queryTermsCopy,
+        isFork && !negateRepoFilter,
+        isArchived && !negateRepoFilter
+    )
 
     return search({ ...args, queryTerms: queryTermsCopy })
 }
@@ -426,19 +472,25 @@ function searchIndexed<
  * @param negateRepoFilter Whether to look only inside or outside the given repo.
  */
 function searchUnindexed<
-    P extends { repo: string; commit: string; queryTerms: string[] },
+    P extends {
+        repo: string
+        isFork: boolean
+        isArchived: boolean
+        commit: string
+        queryTerms: string[]
+    },
     R
 >(
     search: (args: P) => Promise<R>,
     args: P,
     negateRepoFilter = false
 ): Promise<R> {
-    const { repo, commit, queryTerms } = args
+    const { repo, isFork, isArchived, commit, queryTerms } = args
 
     // Create a copy of the args so that concurrent calls to other
     // search methods do not have their query terms unintentionally
     // modified.
-    const queryTermsCopy = Array.from(queryTerms)
+    let queryTermsCopy = Array.from(queryTerms)
 
     if (!negateRepoFilter) {
         // Look in this commit only
@@ -447,6 +499,15 @@ function searchUnindexed<
         // Look outside the repo (not outside the commit)
         queryTermsCopy.push(`-repo:^${repo}$`)
     }
+
+    // If we're a fork, search in forks _for the same repo_. Otherwise,
+    // search in forks only if it's set in the settings. This is also
+    // symmetric for archived repositories.
+    queryTermsCopy = addRepositoryKindTerms(
+        queryTermsCopy,
+        isFork && !negateRepoFilter,
+        isArchived && !negateRepoFilter
+    )
 
     return search({ ...args, queryTerms: queryTermsCopy })
 }
@@ -569,4 +630,27 @@ export async function raceWithDelayOffset<T>(
  */
 async function delay(timeout: number): Promise<undefined> {
     return new Promise(r => setTimeout(r, timeout))
+}
+
+/**
+ * Adds options to include forked and archived repositories.
+ *
+ * @param queryTerms The terms of the search query.
+ * @param includeFork Whether or not the include forked repositories regardless of settings.
+ * @param includeArchived Whether or not the include archived repositories regardless of settings.
+ */
+function addRepositoryKindTerms(
+    queryTerms: string[],
+    includeFork: boolean,
+    includeArchived: boolean
+): string[] {
+    if (includeFork || getConfig('basicCodeIntel.includeForks', false)) {
+        queryTerms.push('fork:yes')
+    }
+
+    if (includeArchived || getConfig('basicCodeIntel.includeArchives', false)) {
+        queryTerms.push('archived:yes')
+    }
+
+    return queryTerms
 }

--- a/shared/search/queries.ts
+++ b/shared/search/queries.ts
@@ -1,7 +1,6 @@
 import { extname } from 'path'
 import * as sourcegraph from 'sourcegraph'
 import { parseGitURI } from '../util/uri'
-import { getConfig } from './config'
 
 /**
  * Create a search query to find definitions of a symbol.
@@ -22,13 +21,13 @@ export function definitionQuery({
 }): string[] {
     const { path } = parseGitURI(new URL(doc.uri))
 
-    return addRepositoryKindTerms([
+    return [
         `^${searchToken}$`,
         'type:symbol',
         'patternType:regexp',
         'case:yes',
         fileExtensionTerm(path, fileExts),
-    ])
+    ]
 }
 
 /**
@@ -50,30 +49,13 @@ export function referencesQuery({
 }): string[] {
     const { path } = parseGitURI(new URL(doc.uri))
 
-    return addRepositoryKindTerms([
+    return [
         `\\b${searchToken}\\b`,
         'type:file',
         'patternType:regexp',
         'case:yes',
         fileExtensionTerm(path, fileExts),
-    ])
-}
-
-/**
- * Adds options to include forked and archived repositories.
- *
- * @param queryTerms The terms of the search query.
- */
-function addRepositoryKindTerms(queryTerms: string[]): string[] {
-    if (getConfig('basicCodeIntel.includeForks', false)) {
-        queryTerms.push('fork:yes')
-    }
-
-    if (getConfig('basicCodeIntel.includeArchives', false)) {
-        queryTerms.push('archived:yes')
-    }
-
-    return queryTerms
+    ]
 }
 
 const blacklist = ['thrift', 'proto', 'graphql']

--- a/shared/util/api.ts
+++ b/shared/util/api.ts
@@ -70,8 +70,6 @@ export class API {
             }
         `
 
-        console.log({query})
-
         interface Response {
             repository: RepoMeta
         }

--- a/shared/util/api.ts
+++ b/shared/util/api.ts
@@ -78,7 +78,11 @@ export class API {
         return data.repository
     }
 
-    /** Determines via introspection if the GraphQL API has iSFork field on the Repository type. */
+    /**
+     * Determines via introspection if the GraphQL API has iSFork field on the Repository type.
+     *
+     * TODO(efritz) - Remove this when we no longer need to support pre-3.15 instances.
+     */
     private async hasForkField(): Promise<boolean> {
         const introspectionQuery = gql`
             query RepositoryIntrospection() {

--- a/shared/util/api.ts
+++ b/shared/util/api.ts
@@ -42,28 +42,63 @@ export interface LineMatch {
     offsetAndLengths: [number, number][]
 }
 
+/** Metadata about a resolved repository. */
+export interface RepoMeta {
+    name: string
+    isFork: boolean
+    isArchived: boolean
+}
+
 export class API {
     /**
-     * Retrieves the name of a repository. Throws an error if the repository
-     * is not known to the Sourcegraph instance.
+     * Retrieves the name and fork/archive status of a repository. This method
+     * throws an error if the repository is not known to the Sourcegraph instance.
      *
      * @param cloneURL The repository's clone URL.
      */
-    public async resolveRepo(cloneURL: string): Promise<string> {
+    public async resolveRepo(cloneURL: string): Promise<RepoMeta> {
+        const metaFields = (await this.hasForkField())
+            ? 'isFork\nisArchived'
+            : ''
+
         const query = gql`
             query ResolveRepo($cloneURL: String!) {
                 repository(cloneURL: $cloneURL) {
                     name
+                    ${metaFields}
                 }
             }
         `
 
+        console.log({query})
+
         interface Response {
-            repository: { name: string }
+            repository: RepoMeta
         }
 
         const data = await queryGraphQL<Response>(query, { cloneURL })
-        return data.repository.name
+        return data.repository
+    }
+
+    /** Determines via introspection if the GraphQL API has iSFork field on the Repository type. */
+    private async hasForkField(): Promise<boolean> {
+        const introspectionQuery = gql`
+            query RepositoryIntrospection() {
+                __type(name: "Repository") {
+                    fields {
+                        name
+                    }
+                }
+            }
+        `
+
+        interface IntrospectionResponse {
+            __type: { fields: { name: string }[] }
+        }
+
+        return (
+            await queryGraphQL<IntrospectionResponse>(introspectionQuery)
+        ).__type.fields.some(field => field.name === 'isFork')
     }
 
     /**


### PR DESCRIPTION
If the user is currently browsing a fork, we should search in forks for definitions and references _in the same repository_, but not in remote repositories.

This was reported in https://github.com/sourcegraph/sourcegraph/issues/9634.