### PR TITLE
resolveRepo: use name, not clone URL

### DIFF
--- a/shared/util/api.ts
+++ b/shared/util/api.ts
@@ -56,14 +56,14 @@ export class API {
      *
      * @param cloneURL The repository's clone URL.
      */
-    public async resolveRepo(cloneURL: string): Promise<RepoMeta> {
+    public async resolveRepo(name: string): Promise<RepoMeta> {
         const metaFields = (await this.hasForkField())
             ? 'isFork\nisArchived'
             : ''
 
         const query = gql`
-            query ResolveRepo($cloneURL: String!) {
-                repository(cloneURL: $cloneURL) {
+            query ResolveRepo($name: String!) {
+                repository(name: $name) {
                     name
                     ${metaFields}
                 }
@@ -74,7 +74,7 @@ export class API {
             repository: RepoMeta
         }
 
-        const data = await queryGraphQL<Response>(query, { cloneURL })
+        const data = await queryGraphQL<Response>(query, { name })
         return data.repository
     }
 

--- a/shared/util/api.ts
+++ b/shared/util/api.ts
@@ -54,7 +54,7 @@ export class API {
      * Retrieves the name and fork/archive status of a repository. This method
      * throws an error if the repository is not known to the Sourcegraph instance.
      *
-     * @param cloneURL The repository's clone URL.
+     * @param name The repository's name.
      */
     public async resolveRepo(name: string): Promise<RepoMeta> {
         const metaFields = (await this.hasForkField())


### PR DESCRIPTION
With https://github.com/sourcegraph/code-intel-extensions/pull/363, basic code intel now calls `resolveRepo()` when creating providers. `resolveRepo()` is called with the repo name, but passes it as the cloneURL in graphQL queries: https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/code-intel-extensions%24+%5CWresolveRepo%28&patternType=regexp

This works for repo names of the form `github.com/sourcegraph/jsonrpc2` (although I think that's by accident, not by design):

![image](https://user-images.githubusercontent.com/1741180/78779621-87990400-799d-11ea-8131-d5498d12c7f3.png)

Unfortunately it fails in many cases (eg. when a `repositoryPathPattern` excluding the hostname from the repo name is set, or for single git repositories), causing code intel to break:

![image](https://user-images.githubusercontent.com/1741180/78779791-d8a8f800-799d-11ea-930d-612114583552.png)

![image](https://user-images.githubusercontent.com/1741180/78780083-5a992100-799e-11ea-8674-5dfd5f7d4ca6.png)

Changing the graphQL query to query by repo name fixes things:

![image](https://user-images.githubusercontent.com/1741180/78779811-e3fc2380-799d-11ea-8c88-ce9aaac16e7f.png)

