### PR TITLE
shared/util: use /.api/graphql?CodeIntelSearch for metric distinction

### DIFF
--- a/shared/util/api.ts
+++ b/shared/util/api.ts
@@ -147,8 +147,10 @@ export class API {
      * @param searchQuery The input to the search function.
      */
     public async findReposViaSearch(searchQuery: string): Promise<string[]> {
+        // Note: the query name "CodeIntelSearch" is used by Sourcegraph's Grafana
+        // dashboards to distinguish searches that originated from code intelligence.
         const query = gql`
-            query Search($query: String!) {
+            query CodeIntelSearch($query: String!) {
                 search(query: $query) {
                     results {
                         results {
@@ -345,8 +347,10 @@ export class API {
         searchQuery: string,
         fileLocal = true
     ): Promise<SearchResult[]> {
+        // Note: the query name "CodeIntelSearch" is used by Sourcegraph's Grafana
+        // dashboards to distinguish searches that originated from code intelligence.
         const query = gql`
-        query Search($query: String!) {
+        query CodeIntelSearch($query: String!) {
             search(query: $query) {
                 results {
                     __typename


### PR DESCRIPTION
Prior to this change, search-based code intel would issue GraphQL requests
with /.api/graphql?Search which made it impossible to differentiate between
code-intel search requests and user's search requests in the Sourcegraph
web UI.

Distinguishing between the two is useful for many different reasons:

- We can apply alerting thresholds to user's search queries and code intel
  search queries independently.
- We can monitor error rates of code intel searches vs. user searches.

This distinction is already made in the dashboards here: https://github.com/sourcegraph/sourcegraph/pull/9986

Side note: if anyone could publish this for me after merge, I would be
extremely grateful :)