### PR TITLE
Update conditions to check for empty arrays in top-level providers

### DIFF
--- a/shared/util/helpers.ts
+++ b/shared/util/helpers.ts
@@ -8,6 +8,18 @@ export function isDefined<T>(value: T | undefined): value is T {
 }
 
 /**
+ * Returns true fi the value is defined and, if an array, contains at least
+ * one element.
+ *
+ * @param value The value to test.
+ */
+export function nonEmpty<T>(
+    value: T | T[] | null | undefined
+): value is T | T[] {
+    return !!value && !(Array.isArray(value) && value.length === 0)
+}
+
+/**
  * Ensure that the given value is an array.
  *
  * @param value The list of values, a single value, or null.

--- a/shared/util/helpers.ts
+++ b/shared/util/helpers.ts
@@ -8,7 +8,7 @@ export function isDefined<T>(value: T | undefined): value is T {
 }
 
 /**
- * Returns true fi the value is defined and, if an array, contains at least
+ * Returns true if the value is defined and, if an array, contains at least
  * one element.
  *
  * @param value The value to test.


### PR DESCRIPTION
We were emitting `codeintel.searchDefinitions` events each time the provider was active and didn't return a precise result.

This PR checks explicitly for empty arrays and guards the emission of events and results when there's nothing interesting to emit.