### PR TITLE
Do not block on range requests

### DIFF
--- a/shared/lsif/providers.test.ts
+++ b/shared/lsif/providers.test.ts
@@ -86,7 +86,7 @@ describe('graphql providers', () => {
     })
 
     describe('references provider', () => {
-        it('should use result from window', async () => {
+        it.only('should use result from window', async () => {
             const queryGraphQLFn = sinon.spy<QueryGraphQLFn<GenericLSIFResponse<ReferencesResponse | null>>>(() =>
                 makeEnvelope({
                     references: {
@@ -118,11 +118,6 @@ describe('graphql providers', () => {
                     })
                 ),
                 [
-                    [
-                        new sourcegraph.Location(new URL('git://repo1?deadbeef1#/d.ts'), range1),
-                        new sourcegraph.Location(new URL('git://repo2?deadbeef2#/e.ts'), range2),
-                        new sourcegraph.Location(new URL('git://repo3?deadbeef3#/f.ts'), range3),
-                    ],
                     [
                         new sourcegraph.Location(new URL('git://repo1?deadbeef1#/a.ts'), range1),
                         new sourcegraph.Location(new URL('git://repo2?deadbeef2#/b.ts'), range2),

--- a/shared/lsif/providers.test.ts
+++ b/shared/lsif/providers.test.ts
@@ -86,7 +86,7 @@ describe('graphql providers', () => {
     })
 
     describe('references provider', () => {
-        it.only('should use result from window', async () => {
+        it('should use result from window', async () => {
             const queryGraphQLFn = sinon.spy<QueryGraphQLFn<GenericLSIFResponse<ReferencesResponse | null>>>(() =>
                 makeEnvelope({
                     references: {

--- a/shared/lsif/providers.ts
+++ b/shared/lsif/providers.ts
@@ -8,6 +8,7 @@ import { hoverPayloadToHover, hoverForPosition } from './hover'
 import { definitionForPosition } from './definition'
 import { referencesForPosition, referencePageForPosition } from './references'
 import { filterLocationsForDocumentHighlights } from './highlights'
+import { raceWithDelayOffset } from '../util/promise'
 
 /**
  * Creates providers powered by LSIF-based code intelligence. This particular
@@ -47,20 +48,39 @@ export function createGraphQLProviders(
     }
 }
 
+/** The time to delay between range queries and an explicit definition/reference/hover request. */
+const RANGE_RESOLUTION_DELAY = 25
+
 /** Retrieve a definition for the current hover position. */
 function definition(
     queryGraphQL: QueryGraphQLFn<any>,
     getRangeFromWindow?: Promise<RangeWindowFactoryFn>
 ): (doc: sourcegraph.TextDocument, position: sourcegraph.Position) => Promise<sourcegraph.Definition> {
     return async (doc: sourcegraph.TextDocument, position: sourcegraph.Position): Promise<sourcegraph.Definition> => {
-        if (getRangeFromWindow) {
-            const range = await (await getRangeFromWindow)(doc, position)
-            if (range?.definitions && range.definitions.length > 0) {
-                return range.definitions
+        const getDefinitionsFromRangeRequest = async (): Promise<sourcegraph.Definition> => {
+            if (getRangeFromWindow) {
+                const range = await (await getRangeFromWindow)(doc, position)
+                if (range?.definitions && range.definitions.length > 0) {
+                    return range.definitions
+                }
             }
+
+            return null
         }
 
-        return definitionForPosition(doc, position, queryGraphQL)
+        // First see if we can query or resolve a window containing this
+        // target position. If we've already requested this range, it should
+        // be a synchronous return that won't trigger the fallback request.
+        // If we don't have the window in memory, wait a very small time for
+        // the window to resolve, then fall back to requesting the definition
+        // for this position explicitly. This fallback will also happen if we
+        // have an empty set of definitions for this position.
+        return raceWithDelayOffset(
+            getDefinitionsFromRangeRequest(),
+            async () => definitionForPosition(doc, position, queryGraphQL),
+            RANGE_RESOLUTION_DELAY,
+            v => v !== null && !(Array.isArray(v) && v.length === 0)
+        )
     }
 }
 
@@ -72,18 +92,41 @@ function references(
     doc: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ) => AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
-    // eslint-disable-next-line @typescript-eslint/require-await
     return async function* (
         doc: sourcegraph.TextDocument,
         position: sourcegraph.Position
     ): AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
-        if (getRangeFromWindow) {
-            const range = await (await getRangeFromWindow)(doc, position)
-            if (range?.references) {
-                yield range?.references
+        const getReferencesFromRangeRequest = async (): Promise<sourcegraph.Location[] | null> => {
+            if (getRangeFromWindow) {
+                const range = await (await getRangeFromWindow)(doc, position)
+                if (range?.references && range.references.length > 0) {
+                    return range.references
+                }
             }
+
+            return null
         }
 
+        // First see if we can query or resolve a window containing this
+        // target position. If we've already requested this range, it should
+        // be a synchronous return that won't trigger the fallback request.
+        // If we don't have the window in memory, wait a very small time for
+        // the window to resolve, then fall back to requesting the hover text
+        // for this position explicitly. This fallback will also happen if we
+        // have a null hover text for this position.
+        const localReferences = await raceWithDelayOffset(
+            getReferencesFromRangeRequest(),
+            () => Promise.resolve(null),
+            RANGE_RESOLUTION_DELAY,
+            v => v !== null && !(Array.isArray(v) && v.length === 0)
+        )
+
+        if (localReferences && localReferences.length < 0) {
+            // Yield any references we have immediately
+            yield localReferences
+        }
+
+        // Replace local references with actual results
         yield* referencesForPosition(doc, position, queryGraphQL)
     }
 }
@@ -94,14 +137,30 @@ function hover(
     getRangeFromWindow?: Promise<RangeWindowFactoryFn>
 ): (doc: sourcegraph.TextDocument, position: sourcegraph.Position) => Promise<sourcegraph.Hover | null> {
     return async (doc: sourcegraph.TextDocument, position: sourcegraph.Position): Promise<sourcegraph.Hover | null> => {
-        if (getRangeFromWindow) {
-            const range = await (await getRangeFromWindow)(doc, position)
-            if (range?.hover) {
-                return hoverPayloadToHover(range?.hover)
+        const getHoverFromRangeRequest = async (): Promise<sourcegraph.Hover | null> => {
+            if (getRangeFromWindow) {
+                const range = await (await getRangeFromWindow)(doc, position)
+                if (range?.hover) {
+                    return hoverPayloadToHover(range?.hover)
+                }
             }
+
+            return null
         }
 
-        return hoverForPosition(doc, position, queryGraphQL)
+        // First see if we can query or resolve a window containing this
+        // target position. If we've already requested this range, it should
+        // be a synchronous return that won't trigger the race request below.
+        // If we don't have the window in memory, wait a very small
+        // time for the window to resolve, then fall back to requesting
+        // the hover text for this position explicitly. This fallback will
+        // also happen if we have a range that does not contain suitable
+        // hover data for this position.
+        return raceWithDelayOffset(
+            getHoverFromRangeRequest(),
+            async () => hoverForPosition(doc, position, queryGraphQL),
+            RANGE_RESOLUTION_DELAY
+        )
     }
 }
 

--- a/shared/lsif/ranges.test.ts
+++ b/shared/lsif/ranges.test.ts
@@ -117,6 +117,18 @@ describe('findOverlappingCodeIntelligenceRange', () => {
             assert.equal(findOverlappingCodeIntelligenceRange(pos, [range]), null)
         }
     })
+
+    it('returns the inner-most range', () => {
+        const ranges = [
+            { range: new sourcegraph.Range(1, 0, 5, 10) },
+            { range: new sourcegraph.Range(2, 0, 4, 10) },
+            { range: new sourcegraph.Range(3, 2, 3, 8) },
+            { range: new sourcegraph.Range(3, 4, 3, 6) },
+        ]
+
+        const pos = new sourcegraph.Position(3, 5)
+        assert.equal(findOverlappingCodeIntelligenceRange(pos, ranges), ranges[3])
+    })
 })
 
 describe('rangesInRangeWindow', () => {

--- a/shared/lsif/ranges.ts
+++ b/shared/lsif/ranges.ts
@@ -180,8 +180,8 @@ export function findOverlappingCodeIntelligenceRange(
     position: sourcegraph.Position,
     ranges: CodeIntelligenceRange[]
 ): CodeIntelligenceRange | null {
-    return (
-        ranges.find(
+    const overlapping =
+        ranges.filter(
             ({
                 range: {
                     start: { line: startLine, character: startCharacter },
@@ -193,7 +193,21 @@ export function findOverlappingCodeIntelligenceRange(
                 // right side check
                 (position.line < endLine || (position.line === endLine && position.character < endCharacter))
         ) || null
-    )
+
+    if (overlapping.length === 0) {
+        return null
+    }
+
+    overlapping.sort((a, b) => {
+        const cmp = b.range.start.line - a.range.start.line
+        if (cmp === 0) {
+            return b.range.start.character - a.range.start.character
+        }
+
+        return cmp
+    })
+
+    return overlapping[0]
 }
 
 const introspectionQuery = gql`

--- a/shared/util/promise.ts
+++ b/shared/util/promise.ts
@@ -1,0 +1,45 @@
+/**
+ * Race an in-flight promise and a promise that will be invoked only after
+ * a timeout. This will favor the primary promise, which should be likely
+ * to resolve fairly quickly.
+ *
+ * This is useful for situations where the primary promise may time-out,
+ * and the fallback promise returns a value that is likely to be resolved
+ * faster but is not as good of a result. This particular situation should
+ * _not_ use Promise.race, as the faster promise will always resolve before
+ * the one with better results.
+ *
+ * @param primary The in-flight happy-path promise.
+ * @param makeFallback A factory that creates a fallback promise.
+ * @param timeout The timeout in ms before the fallback is invoked.
+ * @param filter An optional filter function to determine if a set of results
+ *        should be returned immediately.
+ */
+export async function raceWithDelayOffset<T>(
+    primary: Promise<T>,
+    makeFallback: () => Promise<T>,
+    timeout: number,
+    filter: (v: T) => boolean = v => v !== null
+): Promise<T> {
+    const primaryResults = await Promise.race([primary, delay(timeout)])
+    if (primaryResults !== undefined && filter(primaryResults)) {
+        return primaryResults
+    }
+
+    const fallback = makeFallback()
+    const raceResults = await Promise.race([primary, fallback])
+    if (filter(raceResults)) {
+        return raceResults
+    }
+
+    return fallback
+}
+
+/**
+ * Create a promise that resolves to undefined after the given timeout.
+ *
+ * @param timeout The timeout in ms.
+ */
+async function delay(timeout: number): Promise<undefined> {
+    return new Promise(r => setTimeout(r, timeout))
+}


### PR DESCRIPTION
Range requests can take a while to resolve if there is a lot of data in a window. This is especially problematic in symbol-dense code such as Typescript (https://sourcegraph.com/github.com/sourcegraph/sourcegraph@138e2f89a0136fab21d5f76a981c38e686f281d9/-/blob/web/src/search/input/MonacoQueryInput.tsx#L193:13).

This changes the providers to request a range from the API, but only take a short 25ms delay until requesting the definition or hover for the position explicitly. The range request will continue to resolve in the background so once it's in memory all other requests will no longer need to make explicit requests for local data.