### PR TITLE
Fix undefined property in introspection query

### DIFF
--- a/shared/lsif/ranges.ts
+++ b/shared/lsif/ranges.ts
@@ -227,7 +227,7 @@ interface IntrospectionResponse {
 
 /** Determine if the LSIF query resolvers have a ranges function. */
 async function hasRangesQuery(queryGraphQL: QueryGraphQLFn<IntrospectionResponse> = sgQueryGraphQL): Promise<boolean> {
-    return (await queryGraphQL(introspectionQuery)).__type.fields.some(field => field.name === 'ranges')
+    return (await queryGraphQL(introspectionQuery)).__type?.fields.some(field => field.name === 'ranges') || false
 }
 
 const rangesQuery = gql`


### PR DESCRIPTION
This was causing an error on 3.16, which did not have the query type.