### PR TITLE
Fix promise resolution in noop combined providers

### DIFF
--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -63,7 +63,7 @@ export type DocumentHighlightProvider = (
 ) => AsyncGenerator<sourcegraph.DocumentHighlight[] | null, void, undefined>
 
 export const noopProviders = {
-    definitionAndHover: (): Promise<DefinitionAndHover | null> => new Promise(() => {}),
+    definitionAndHover: (): Promise<DefinitionAndHover | null> => Promise.resolve(null),
     definition: noopAsyncGenerator,
     references: noopAsyncGenerator,
     hover: noopAsyncGenerator,


### PR DESCRIPTION
The noop definitionAndHover provider did not resolve, which made it block on all hover and definition requests for instances without LSIF providers enabled.