### PR TITLE
Simplify provider caches

### DIFF
--- a/shared/lsif/providers.ts
+++ b/shared/lsif/providers.ts
@@ -1,7 +1,7 @@
 import * as sourcegraph from 'sourcegraph'
 import { noopProviders, CombinedProviders, DefinitionAndHover } from '../providers'
 import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
-import { asyncGeneratorFromPromise, cacheProviderPromise } from '../util/ix'
+import { asyncGeneratorFromPromise, cachePromiseProvider } from '../util/ix'
 import { Logger } from '../logging'
 import { RangeWindowFactoryFn, makeRangeWindowFactory } from './ranges'
 import { referencesForPosition, referencePageForPosition } from './references'
@@ -40,7 +40,7 @@ export function createGraphQLProviders(
     getRangeFromWindow?: Promise<RangeWindowFactoryFn>
 ): CombinedProviders {
     return {
-        definitionAndHover: cacheProviderPromise(definitionAndHover(queryGraphQL, getRangeFromWindow)),
+        definitionAndHover: cachePromiseProvider(definitionAndHover(queryGraphQL, getRangeFromWindow)),
         references: references(queryGraphQL, getRangeFromWindow),
         documentHighlights: asyncGeneratorFromPromise(documentHighlights(queryGraphQL, getRangeFromWindow)),
     }

--- a/shared/providers.test.ts
+++ b/shared/providers.test.ts
@@ -203,9 +203,7 @@ describe('createHoverProvider', () => {
             () => asyncGeneratorFromValues([hover1, hover2])
         ).provideHover(textDocument, position) as Observable<sourcegraph.Badged<sourcegraph.Hover>>
 
-        const mmm = await gatherValues(result)
-        console.log({ mmm })
-        assert.deepStrictEqual(mmm, [{ ...hover1, alerts: [HoverAlerts.lsp] }, hover2])
+        assert.deepStrictEqual(await gatherValues(result), [{ ...hover1, alerts: [HoverAlerts.lsp] }, hover2])
     })
 
     it('falls back to basic when precise results are not found', async () => {

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -434,5 +434,5 @@ export function badgeValues<T extends object>(
 function wrapProvider<P extends unknown[], R>(
     func: (...args: P) => AsyncGenerator<R, void, void>
 ): (...args: P) => Observable<R> {
-    return (...args) =>  observableFromAsyncIterator(() => func(...args))
+    return (...args) => observableFromAsyncIterator(() => func(...args))
 }

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -1,5 +1,4 @@
 import { NEVER, Observable } from 'rxjs'
-import { shareReplay } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { impreciseBadge } from './badges'
 import { LanguageSpec, LSIFSupport } from './language-specs/spec'
@@ -428,43 +427,12 @@ export function badgeValues<T extends object>(
 }
 
 /**
- * Converts an async generator provider into an observable provider. This
- * also memoizes the previous result. This reduces the number of definition
- * requests from two to one on each hover.
+ * Converts an async generator provider into an observable provider.
  *
- * The memoization was originally a workaround for #1321 (below), but should
- * now be kept as relying on memoization here is an efficient replacement for
- * a local cache of search results.
- *
- * [^1]: https://github.com/sourcegraph/sourcegraph/issues/1321
- *
- * @param func A factory to create the provider.
+ * @param func A function that returns a the provider.
  */
 function wrapProvider<P extends unknown[], R>(
     func: (...args: P) => AsyncGenerator<R, void, void>
 ): (...args: P) => Observable<R> {
-    let previousResult: Observable<R>
-    let previousArguments: P
-    return (...args) => {
-        if (previousArguments && compareParameters(previousArguments, args)) {
-            return previousResult
-        }
-        previousArguments = args
-        previousResult = observableFromAsyncIterator(() => func(...args)).pipe(shareReplay(1))
-        return previousResult
-    }
-}
-
-/**
- * Compare the parameters of definition, reference, and hover providers. This
- * will only compare the document and position parameters and will ignore the
- * third parameter on the references provider.
- *
- * @param x The first set of parameters to compare.
- * @param y The second set of parameters to compare.
- */
-function compareParameters<P extends unknown>(parameters1: P, parameters2: P): boolean {
-    const [textDocument1, position1] = parameters1 as [sourcegraph.TextDocument, sourcegraph.Position]
-    const [textDocument2, position2] = parameters2 as [sourcegraph.TextDocument, sourcegraph.Position]
-    return textDocument1.uri === textDocument2.uri && position1.isEqual(position2)
+    return (...args) =>  observableFromAsyncIterator(() => func(...args))
 }

--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -6,7 +6,7 @@ import { FilterDefinitions, LanguageSpec } from '../language-specs/spec'
 import { Providers, SourcegraphProviders } from '../providers'
 import { API, RepoMeta } from '../util/api'
 import { asArray, isDefined } from '../util/helpers'
-import { asyncGeneratorFromPromise, cacheProviderPromise } from '../util/ix'
+import { asyncGeneratorFromPromise, cachePromiseProvider } from '../util/ix'
 import { parseGitURI } from '../util/uri'
 import { Result, resultToLocation, searchResultToResults } from './conversion'
 import { findDocstring } from './docstrings'
@@ -274,7 +274,7 @@ export function createProviders(
     }
 
     return {
-        definition: asyncGeneratorFromPromise(cacheProviderPromise(definition)),
+        definition: asyncGeneratorFromPromise(cachePromiseProvider(definition)),
         references: asyncGeneratorFromPromise(references),
         hover: asyncGeneratorFromPromise(hover),
         documentHighlights: asyncGeneratorFromPromise(documentHighlights),

--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -6,7 +6,7 @@ import { FilterDefinitions, LanguageSpec } from '../language-specs/spec'
 import { Providers, SourcegraphProviders } from '../providers'
 import { API, RepoMeta } from '../util/api'
 import { asArray, isDefined } from '../util/helpers'
-import { asyncGeneratorFromPromise } from '../util/ix'
+import { asyncGeneratorFromPromise, cacheProviderPromise } from '../util/ix'
 import { parseGitURI } from '../util/uri'
 import { Result, resultToLocation, searchResultToResults } from './conversion'
 import { findDocstring } from './docstrings'
@@ -74,7 +74,7 @@ export function createProviders(
     }
 
     /**
-     * Return the text document content adn the search token found under the
+     * Return the text document content and the search token found under the
      * current hover position. Returns undefined if either piece of data could
      * not be determined.
      *
@@ -274,7 +274,7 @@ export function createProviders(
     }
 
     return {
-        definition: asyncGeneratorFromPromise(definition),
+        definition: asyncGeneratorFromPromise(cacheProviderPromise(definition)),
         references: asyncGeneratorFromPromise(references),
         hover: asyncGeneratorFromPromise(hover),
         documentHighlights: asyncGeneratorFromPromise(documentHighlights),

--- a/shared/util/ix.test.ts
+++ b/shared/util/ix.test.ts
@@ -1,5 +1,14 @@
+import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
+import * as sourcegraph from 'sourcegraph'
 import * as assert from 'assert'
-import { asyncGeneratorFromPromise, concat, flatMapConcurrent, observableFromAsyncIterator } from './ix'
+import {
+    asyncGeneratorFromPromise,
+    concat,
+    flatMapConcurrent,
+    observableFromAsyncIterator,
+    cacheProviderPromise,
+    PROMISE_CACHE_CAPACITY,
+} from './ix'
 
 describe('observableFromAsyncIterator', () => {
     it('converts iterator into an observable', async () => {
@@ -79,6 +88,83 @@ describe('asyncGeneratorFromPromise', () => {
         const iterable = asyncGeneratorFromPromise(async (value: number) => Promise.resolve(value * 2))
 
         assert.deepStrictEqual(await gatherValues(iterable(24)), [48])
+    })
+})
+
+const textDocument1 = createStubTextDocument({
+    uri: 'https://sourcegraph.test/repo@rev/-/raw/foo.ts',
+    languageId: 'typescript',
+    text: undefined,
+})
+const textDocument2 = createStubTextDocument({
+    uri: 'https://sourcegraph.test/repo@rev/-/raw/bar.ts',
+    languageId: 'typescript',
+    text: undefined,
+})
+
+const textDocument3 = createStubTextDocument({
+    uri: 'https://sourcegraph.test/repo@rev/-/raw/baz.ts',
+    languageId: 'typescript',
+    text: undefined,
+})
+
+const position1 = new sourcegraph.Position(10, 1)
+const position2 = new sourcegraph.Position(10, 2)
+const position3 = new sourcegraph.Position(10, 3)
+
+describe('cachePromiseProvider', () => {
+    it('caches the result', async () => {
+        let calls = 0
+        let resolutions = 0
+
+        const cachedPromise = cacheProviderPromise(
+            (textDocument: sourcegraph.TextDocument, position: sourcegraph.Position) => {
+                calls++
+
+                return new Promise<number>(resolve => {
+                    resolutions++
+                    resolve(position.line + position.character * 2)
+                })
+            }
+        )
+
+        const promise = cachedPromise(textDocument1, position1)
+        assert.strictEqual(await promise, 12)
+        assert.strictEqual(await promise, 12)
+        assert.strictEqual(await cachedPromise(textDocument2, position2), 14)
+        assert.strictEqual(await cachedPromise(textDocument3, position3), 16)
+        assert.strictEqual(await cachedPromise(textDocument2, position2), 14)
+        assert.strictEqual(await cachedPromise(textDocument1, position1), 12)
+        assert.strictEqual(calls, 3)
+        assert.strictEqual(resolutions, 3)
+    })
+
+    it('is bounded', async () => {
+        let calls = 0
+
+        const cachedPromise = cacheProviderPromise(
+            (textDocument: sourcegraph.TextDocument, position: sourcegraph.Position) => {
+                calls++
+                return new Promise<number>(resolve => resolve(position.line + position.character * 2))
+            }
+        )
+
+        for (let index = 0; index < PROMISE_CACHE_CAPACITY * 2; index++) {
+            await cachedPromise(textDocument1, new sourcegraph.Position(index, 1))
+        }
+        assert.strictEqual(calls, PROMISE_CACHE_CAPACITY * 2)
+
+        // Ensure that the later half are still cached - no new calls
+        for (let index = 0; index < PROMISE_CACHE_CAPACITY; index++) {
+            await cachedPromise(textDocument1, new sourcegraph.Position(2 * PROMISE_CACHE_CAPACITY - index - 1, 1))
+        }
+        assert.strictEqual(calls, PROMISE_CACHE_CAPACITY * 2)
+
+        // Ensure that the first half is not cached - all new calls
+        for (let index = 0; index < PROMISE_CACHE_CAPACITY; index++) {
+            await cachedPromise(textDocument1, new sourcegraph.Position(index, 1))
+        }
+        assert.strictEqual(calls, PROMISE_CACHE_CAPACITY * 3)
     })
 })
 

--- a/shared/util/ix.test.ts
+++ b/shared/util/ix.test.ts
@@ -6,7 +6,7 @@ import {
     concat,
     flatMapConcurrent,
     observableFromAsyncIterator,
-    cacheProviderPromise,
+    cachePromiseProvider,
     PROMISE_CACHE_CAPACITY,
 } from './ix'
 
@@ -117,7 +117,7 @@ describe('cachePromiseProvider', () => {
         let calls = 0
         let resolutions = 0
 
-        const cachedPromise = cacheProviderPromise(
+        const cachedPromise = cachePromiseProvider(
             (textDocument: sourcegraph.TextDocument, position: sourcegraph.Position) => {
                 calls++
 
@@ -142,7 +142,7 @@ describe('cachePromiseProvider', () => {
     it('is bounded', async () => {
         let calls = 0
 
-        const cachedPromise = cacheProviderPromise(
+        const cachedPromise = cachePromiseProvider(
             (textDocument: sourcegraph.TextDocument, position: sourcegraph.Position) => {
                 calls++
                 return new Promise<number>(resolve => resolve(position.line + position.character * 2))

--- a/shared/util/ix.ts
+++ b/shared/util/ix.ts
@@ -124,7 +124,7 @@ export const PROMISE_CACHE_CAPACITY = 5
  *
  * @param func The promise function.
  */
-export function cacheProviderPromise<P extends unknown[], R>(
+export function cachePromiseProvider<P extends unknown[], R>(
     func: (...args: P) => Promise<R>,
     cacheCapacity: number = PROMISE_CACHE_CAPACITY
 ): (...args: P) => Promise<R> {

--- a/shared/util/ix.ts
+++ b/shared/util/ix.ts
@@ -119,9 +119,10 @@ export function asyncGeneratorFromPromise<P extends unknown[], R>(
 export const PROMISE_CACHE_CAPACITY = 5
 
 /**
- * TODO
+ * Memoizes a function that returns a promise. Internally, this maintains a simple
+ * bounded LRU cache.
  *
- * @param func TODO
+ * @param func The promise function.
  */
 export function cacheProviderPromise<P extends unknown[], R>(
     func: (...args: P) => Promise<R>,

--- a/shared/util/ix.ts
+++ b/shared/util/ix.ts
@@ -1,3 +1,4 @@
+import * as sourcegraph from 'sourcegraph'
 import { AsyncIterableX, from, of } from 'ix/asynciterable'
 import { MergeAsyncIterable } from 'ix/asynciterable/merge'
 import { flatMap, share } from 'ix/asynciterable/operators'
@@ -112,4 +113,56 @@ export function asyncGeneratorFromPromise<P extends unknown[], R>(
     return async function* (...args: P): AsyncGenerator<R, void, unknown> {
         yield await func(...args)
     }
+}
+
+/** The maximum number of promise results to cache. */
+export const PROMISE_CACHE_CAPACITY = 5
+
+/**
+ * TODO
+ *
+ * @param func TODO
+ */
+export function cacheProviderPromise<P extends unknown[], R>(
+    func: (...args: P) => Promise<R>,
+    cacheCapacity: number = PROMISE_CACHE_CAPACITY
+): (...args: P) => Promise<R> {
+    interface CacheEntry {
+        args: P
+        value: Promise<R>
+    }
+    const cache: CacheEntry[] = []
+
+    return (...args) => {
+        for (const [index, entry] of cache.entries()) {
+            if (compareProviderArguments(entry.args, args)) {
+                if (index !== 0) {
+                    cache.splice(index, 1)
+                    cache.unshift(entry)
+                }
+                return entry.value
+            }
+        }
+
+        const value = func(...args)
+        cache.unshift({ args, value })
+        while (cache.length > cacheCapacity) {
+            cache.pop()
+        }
+        return value
+    }
+}
+
+/**
+ * Compare the arguments of definition, reference, and hover providers. This
+ * will only compare the document and position arguments and will ignore the
+ * third parameter on the references provider.
+ *
+ * @param arguments1 The first set of arguments to compare.
+ * @param arguments2 The second set of arguments to compare.
+ */
+function compareProviderArguments<P extends unknown>(arguments1: P, arguments2: P): boolean {
+    const [textDocument1, position1] = arguments1 as [sourcegraph.TextDocument, sourcegraph.Position]
+    const [textDocument2, position2] = arguments2 as [sourcegraph.TextDocument, sourcegraph.Position]
+    return textDocument1.uri === textDocument2.uri && position1.isEqual(position2)
 }


### PR DESCRIPTION
This is to clean up a bit before https://github.com/sourcegraph/code-intel-extensions/issues/475, which requires that we cache closer to the original providers in order to effectively determine the information we need without recomputing multiple times per request.

This moves the search cache closer to the search provider for definitions, rather than memoizing the combined LSIF/LSP/Search providers.