### PR TITLE
Use standard URL in package.json repository object

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "github:sourcegraph/code-intel-extensions"
+    "url": "https://github.com/sourcegraph/code-intel-extensions"
   },
   "scripts": {
     "prettier": "prettier --write --list-different '**/*.{ts,js?(on),md,yml}'",


### PR DESCRIPTION
The `github:OWNER/REPO` syntax might be handled specially by some tools, but it's non-standard. It also breaks the `Repository` link on the extension's page at (eg) https://sourcegraph.com/extensions/sourcegraph/go.