### PR TITLE
specify path to programs in ../../node_modules/.bin

### DIFF
--- a/extensions/go/node_modules/.bin
+++ b/extensions/go/node_modules/.bin
@@ -1,1 +1,0 @@
-../../../node_modules/.bin

--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -37,10 +37,10 @@
     "onLanguage:go"
   ],
   "scripts": {
-    "build": "tsc -b . && parcel build --out-file extension.js src/extension.ts && dot-json dist/extension.map sourceRoot https://sourcegraph.com/github.com/sourcegraph/sourcegraph-go@$(git rev-parse HEAD)/-/raw/extension/src/",
-    "config-types": "dot-json package.json contributes.configuration | json2ts --unreachableDefinitions --style.singleQuote --no-style.semi -o src/settings.ts",
-    "symlink-package": "mkdirp dist && lnfs ./package.json ./dist/package.json",
-    "serve": "yarn run symlink-package && parcel serve --no-hmr --out-file dist/extension.js src/extension.ts",
+    "build": "../../node_modules/.bin/tsc -b . && ../../node_modules/.bin/parcel build --out-file extension.js src/extension.ts && ../../node_modules/.bin/dot-json dist/extension.map sourceRoot https://sourcegraph.com/github.com/sourcegraph/sourcegraph-go@$(git rev-parse HEAD)/-/raw/extension/src/",
+    "config-types": "../../node_modules/.bin/dot-json package.json contributes.configuration | ../../node_modules/.bin/json2ts --unreachableDefinitions --style.singleQuote --no-style.semi -o src/settings.ts",
+    "symlink-package": "../../node_modules/.bin/mkdirp dist && ../../node_modules/.bin/lnfs ./package.json ./dist/package.json",
+    "serve": "yarn run symlink-package && ../../node_modules/.bin/parcel serve --no-hmr --out-file dist/extension.js src/extension.ts",
     "sourcegraph:prepublish": "yarn run build",
     "publish": "yarn -s && src -config \"${SRC_CONFIG}\" ext publish"
   },

--- a/extensions/template/package.json
+++ b/extensions/template/package.json
@@ -35,10 +35,10 @@
     "*"
   ],
   "scripts": {
-    "build": "tsc -b . && parcel build --out-file extension.js src/extension.ts",
-    "config-types": "dot-json package.json contributes.configuration | json2ts --unreachableDefinitions --style.singleQuote --no-style.semi -o ../../shared/search/settings.ts",
-    "symlink-package": "mkdirp dist && lnfs ./package.json ./dist/package.json",
-    "serve": "yarn run symlink-package && parcel serve --no-hmr --out-file dist/extension.js src/extension.ts",
+    "build": "../../node_modules/.bin/tsc -b . && ../../node_modules/.bin/parcel build --out-file extension.js src/extension.ts",
+    "config-types": "../../node_modules/.bin/dot-json package.json contributes.configuration | ../../node_modules/.bin/json2ts --unreachableDefinitions --style.singleQuote --no-style.semi -o ../../shared/search/settings.ts",
+    "symlink-package": "../../node_modules/.bin/mkdirp dist && ../../node_modules/.bin/lnfs ./package.json ./dist/package.json",
+    "serve": "yarn run symlink-package && ../../node_modules/.bin/parcel serve --no-hmr --out-file dist/extension.js src/extension.ts",
     "sourcegraph:prepublish": "yarn run build",
     "publish": "yarn -s && src -config \"${SRC_CONFIG}\" ext publish"
   },

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -41,10 +41,10 @@
     "onLanguage:javascript"
   ],
   "scripts": {
-    "build": "tsc -b . && parcel build --out-file extension.js src/extension.ts && dot-json dist/extension.map sourceRoot https://sourcegraph.com/github.com/sourcegraph/sourcegraph-typescript@$(git rev-parse HEAD)/-/raw/extension/src/",
-    "config-types": "dot-json package.json contributes.configuration | json2ts --unreachableDefinitions --style.singleQuote --no-style.semi -o src/settings.ts",
-    "symlink-package": "mkdirp dist && lnfs ./package.json ./dist/package.json",
-    "serve": "yarn run symlink-package && parcel serve --no-hmr --out-file dist/extension.js src/extension.ts",
+    "build": "../../node_modules/.bin/tsc -b . && ../../node_modules/.bin/parcel build --out-file extension.js src/extension.ts && ../../node_modules/.bin/dot-json dist/extension.map sourceRoot https://sourcegraph.com/github.com/sourcegraph/sourcegraph-typescript@$(git rev-parse HEAD)/-/raw/extension/src/",
+    "config-types": "../../node_modules/.bin/dot-json package.json contributes.configuration | ../../node_modules/.bin/json2ts --unreachableDefinitions --style.singleQuote --no-style.semi -o src/settings.ts",
+    "symlink-package": "../../node_modules/.bin/mkdirp dist && ../../node_modules/.bin/lnfs ./package.json ./dist/package.json",
+    "serve": "yarn run symlink-package && ../../node_modules/.bin/parcel serve --no-hmr --out-file dist/extension.js src/extension.ts",
     "sourcegraph:prepublish": "yarn run build",
     "publish": "yarn -s && src -config \"${SRC_CONFIG}\" ext publish"
   },


### PR DESCRIPTION
Without the full paths, the invocations of programs such as `mkdirp`, `lnfs`, and `parcel` were failing, both when run like `cd extensions/go && yarn` and `yarn --cwd extensions/go`:

```
$ yarn serve
yarn run v1.22.4
$ yarn run symlink-package && parcel serve --no-hmr --out-file dist/extension.js src/extension.ts
$ mkdirp dist && lnfs ./package.json ./dist/package.json
/bin/sh: 1: mkdirp: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Were they ever working for other people (without local modifications/workarounds such as manual symlinks)?