### PR TITLE
Parse range output lazily

### DIFF
--- a/shared/lsif/providers.test.ts
+++ b/shared/lsif/providers.test.ts
@@ -33,7 +33,7 @@ describe('graphql providers', () => {
             const getBulkLocalIntelligence = Promise.resolve(() =>
                 Promise.resolve({
                     range: range1,
-                    definitions: [
+                    definitions: () => [
                         new sourcegraph.Location(new URL('git://repo1?deadbeef1#/a.ts'), range1),
                         new sourcegraph.Location(new URL('git://repo2?deadbeef2#/b.ts'), range2),
                         new sourcegraph.Location(new URL('git://repo3?deadbeef3#/c.ts'), range3),
@@ -125,7 +125,7 @@ describe('graphql providers', () => {
             const getBulkLocalIntelligence = Promise.resolve(() =>
                 Promise.resolve({
                     range: range1,
-                    references: [
+                    references: () => [
                         new sourcegraph.Location(new URL('git://repo1?deadbeef1#/d.ts'), range1),
                         new sourcegraph.Location(new URL('git://repo2?deadbeef2#/e.ts'), range2),
                         new sourcegraph.Location(new URL('git://repo3?deadbeef3#/f.ts'), range3),
@@ -285,7 +285,7 @@ describe('graphql providers', () => {
             const getBulkLocalIntelligence = Promise.resolve(() =>
                 Promise.resolve({
                     range: range1,
-                    references: [
+                    references: () => [
                         new sourcegraph.Location(new URL('git://repo?rev#foo.ts'), range1),
                         new sourcegraph.Location(new URL('git://repo?rev#bar.ts'), range2),
                         new sourcegraph.Location(new URL('git://repo?rev#foo.ts'), range3),

--- a/shared/lsif/providers.ts
+++ b/shared/lsif/providers.ts
@@ -61,9 +61,9 @@ function definitionAndHover(
         const getDefinitionAndHoverFromRangeRequest = async (): Promise<DefinitionAndHover | null> => {
             if (getRangeFromWindow) {
                 const range = await (await getRangeFromWindow)(textDocument, position)
-                if (range?.definitions && range?.hover) {
+                if (range?.definitions) {
                     const definitions = range.definitions()
-                    if (definitions.length > 0) {
+                    if (definitions.length > 0 && range?.hover) {
                         return {
                             definition: definitions,
                             hover: hoverPayloadToHover(range.hover),

--- a/shared/lsif/providers.ts
+++ b/shared/lsif/providers.ts
@@ -61,10 +61,13 @@ function definitionAndHover(
         const getDefinitionAndHoverFromRangeRequest = async (): Promise<DefinitionAndHover | null> => {
             if (getRangeFromWindow) {
                 const range = await (await getRangeFromWindow)(textDocument, position)
-                if (range?.definitions && range.definitions.length > 0 && range?.hover) {
-                    return {
-                        definition: range.definitions,
-                        hover: hoverPayloadToHover(range.hover),
+                if (range?.definitions && range?.hover) {
+                    const definitions = range.definitions()
+                    if (definitions.length > 0) {
+                        return {
+                            definition: definitions,
+                            hover: hoverPayloadToHover(range.hover),
+                        }
                     }
                 }
             }
@@ -100,8 +103,11 @@ function references(
         const getReferencesFromRangeRequest = async (): Promise<sourcegraph.Location[] | null> => {
             if (getRangeFromWindow) {
                 const range = await (await getRangeFromWindow)(textDocument, position)
-                if (range?.references && range.references.length > 0) {
-                    return range.references
+                if (range?.references) {
+                    const references = range.references()
+                    if (references.length > 0) {
+                        return range.references()
+                    }
                 }
             }
 
@@ -144,7 +150,10 @@ export function documentHighlights(
         if (getRangeFromWindow) {
             const range = await (await getRangeFromWindow)(textDocument, position)
             if (range?.references) {
-                return filterLocationsForDocumentHighlights(textDocument, range?.references)
+                const references = range?.references()
+                if (references.length > 0) {
+                    return filterLocationsForDocumentHighlights(textDocument, references)
+                }
             }
         }
 

--- a/shared/lsif/ranges.test.ts
+++ b/shared/lsif/ranges.test.ts
@@ -167,19 +167,29 @@ describe('rangesInRangeWindow', () => {
             })
         )
 
-        assert.deepEqual(await rangesInRangeWindow(document, 10, 20, queryGraphQLFn), [
-            {
-                range: range1,
-                definitions: [new sourcegraph.Location(new URL('git://repo?rev#/bar.ts'), range2)],
-                references: [new sourcegraph.Location(new URL('git://repo?rev#/baz.ts'), range3)],
-                hover: {
-                    markdown: {
-                        text: 'foo',
-                    },
+        const results = await rangesInRangeWindow(document, 10, 20, queryGraphQLFn)
+
+        assert.deepEqual(
+            (results || []).map(result => ({
+                range: result?.range,
+                definitions: result.definitions?.(),
+                references: result.references?.(),
+                hover: result?.hover,
+            })),
+            [
+                {
                     range: range1,
+                    definitions: [new sourcegraph.Location(new URL('git://repo?rev#/bar.ts'), range2)],
+                    references: [new sourcegraph.Location(new URL('git://repo?rev#/baz.ts'), range3)],
+                    hover: {
+                        markdown: {
+                            text: 'foo',
+                        },
+                        range: range1,
+                    },
                 },
-            },
-        ])
+            ]
+        )
     })
 
     it('should deal with empty payload', async () => {


### PR DESCRIPTION
This is a partial resolution to https://github.com/sourcegraph/sourcegraph/issues/13733.

The change in https://github.com/sourcegraph/sourcegraph/pull/13746 will make this less effective, but only for new instances. This change will have a some effect on new instances and a large effect on old ones.

It is expensive to eagerly convert all of the location data from a range response. We instead do it on demand the first request and cache the values for subsequent requests. After all, _most_ of the ranges won't be hovered over so we were eagerly doing work that never needed to be done in the first place.