### PR TITLE
Lower range window size

### DIFF
--- a/shared/lsif/ranges.test.ts
+++ b/shared/lsif/ranges.test.ts
@@ -49,22 +49,24 @@ describe('findOverlappingWindows', () => {
 })
 
 describe('calculateRangeWindow', () => {
+    const testWindowSize = 100
+
     it('centers window around line', () => {
-        assert.deepEqual(calculateRangeWindow(200, 0, undefined), [150, 250])
+        assert.deepEqual(calculateRangeWindow(200, 0, undefined, testWindowSize), [150, 250])
     })
 
     it('respects lower and upper bounds', () => {
-        assert.deepEqual(calculateRangeWindow(200, 175, 225), [175, 225])
+        assert.deepEqual(calculateRangeWindow(200, 175, 225, testWindowSize), [175, 225])
     })
 
     it('gives upper slack to start line', () => {
-        assert.deepEqual(calculateRangeWindow(200, 0, 225), [125, 225])
-        assert.deepEqual(calculateRangeWindow(200, 140, 225), [140, 225])
+        assert.deepEqual(calculateRangeWindow(200, 0, 225, testWindowSize), [125, 225])
+        assert.deepEqual(calculateRangeWindow(200, 140, 225, testWindowSize), [140, 225])
     })
 
     it('gives lower slack to end line', () => {
-        assert.deepEqual(calculateRangeWindow(200, 175, undefined), [175, 275])
-        assert.deepEqual(calculateRangeWindow(200, 175, 260), [175, 260])
+        assert.deepEqual(calculateRangeWindow(200, 175, undefined, testWindowSize), [175, 275])
+        assert.deepEqual(calculateRangeWindow(200, 175, 260, testWindowSize), [175, 260])
     })
 })
 

--- a/shared/lsif/ranges.ts
+++ b/shared/lsif/ranges.ts
@@ -6,7 +6,7 @@ import { HoverPayload } from './definition-hover'
 import { GenericLSIFResponse, queryLSIF } from './api'
 
 /** The size of the bounds on each ranges request. */
-const RANGE_WINDOW_SIZE = 100
+const RANGE_WINDOW_SIZE = 50
 
 /**
  * The maximum number of documents to store windows for. This value can be
@@ -20,7 +20,7 @@ const RANGE_WINDOW_SIZE = 100
  * good enough v1 to stop things from slowing to a crawl in the vast majority
  * of circumstances.
  */
-const WINDOW_CACHE_CAPACITY = 5
+const WINDOW_CACHE_CAPACITY = 10
 
 /** The type returned by makeRangeWindowFactory. */
 export type RangeWindowFactoryFn = (
@@ -158,9 +158,15 @@ export async function findOverlappingWindows(
  * @param line The target window center.
  * @param lowerBound The minimum lower bound of the window.
  * @param upperBound The maximum upper bound of the window.
+ * @param windowSize The target number of lines in the calculated window.
  */
-export function calculateRangeWindow(line: number, lowerBound: number, upperBound?: number): [number, number] {
-    const radius = RANGE_WINDOW_SIZE / 2
+export function calculateRangeWindow(
+    line: number,
+    lowerBound: number,
+    upperBound?: number,
+    windowSize = RANGE_WINDOW_SIZE
+): [number, number] {
+    const radius = windowSize / 2
     const candidateStartLine = line - radius
     const candidateEndLine = line + radius
     const lowerSlack = lowerBound - candidateStartLine


### PR DESCRIPTION
This is a partial resolution to https://github.com/sourcegraph/sourcegraph/issues/13733.

This is another partial mitigation that will request smaller range windows more frequently. 25 lines on either side of a hover is still a good range and should not be noticeable at all.