### PR TITLE
Add setting to disable range queries

### DIFF
--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -80,6 +80,10 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
           "type": "boolean"
         },
+        "codeIntel.disableRangeQueries": {
+          "description": "Whether to fetch multiple precise definitions and references on hover.",
+          "type": "boolean"
+        },
         "basicCodeIntel.includeForks": {
           "description": "Whether to include forked repositories in search results.",
           "type": "boolean"

--- a/extensions/go/src/settings.ts
+++ b/extensions/go/src/settings.ts
@@ -11,6 +11,10 @@ export interface Settings {
      */
     'codeIntel.lsif'?: boolean
     /**
+     * Whether to fetch multiple precise definitions and references on hover.
+     */
+    'codeIntel.disableRangeQueries'?: boolean
+    /**
      * Whether to include forked repositories in search results.
      */
     'basicCodeIntel.includeForks'?: boolean

--- a/extensions/template/package.json
+++ b/extensions/template/package.json
@@ -50,6 +50,10 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
           "type": "boolean"
         },
+        "codeIntel.disableRangeQueries": {
+          "description": "Whether to fetch multiple precise definitions and references on hover.",
+          "type": "boolean"
+        },
         "basicCodeIntel.includeForks": {
           "description": "Whether to include forked repositories in search results.",
           "type": "boolean"

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -84,6 +84,10 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
           "type": "boolean"
         },
+        "codeIntel.disableRangeQueries": {
+          "description": "Whether to fetch multiple precise definitions and references on hover.",
+          "type": "boolean"
+        },
         "basicCodeIntel.includeForks": {
           "description": "Whether to include forked repositories in search results.",
           "type": "boolean"

--- a/extensions/typescript/src/settings.ts
+++ b/extensions/typescript/src/settings.ts
@@ -62,7 +62,7 @@ export interface Settings {
      * Settings to be written into an npmrc in key/value format. Can be used to specify custom registries and tokens.
      */
     'typescript.npmrc'?: {
-        [k: string]: any
+        [k: string]: unknown
     }
     /**
      * Whether to restart the language server after dependencies were installed (default true)

--- a/extensions/typescript/src/settings.ts
+++ b/extensions/typescript/src/settings.ts
@@ -11,6 +11,10 @@ export interface Settings {
      */
     'codeIntel.lsif'?: boolean
     /**
+     * Whether to fetch multiple precise definitions and references on hover.
+     */
+    'codeIntel.disableRangeQueries'?: boolean
+    /**
      * Whether to include forked repositories in search results.
      */
     'basicCodeIntel.includeForks'?: boolean

--- a/shared/lsif/ranges.ts
+++ b/shared/lsif/ranges.ts
@@ -59,6 +59,12 @@ interface RangeWindow {
 export async function makeRangeWindowFactory(
     queryGraphQL: QueryGraphQLFn<any> = sgQueryGraphQL
 ): Promise<RangeWindowFactoryFn> {
+    const disabled = !!sourcegraph.configuration.get().get('codeIntel.disableRangeQueries')
+    if (disabled) {
+        // No-op if the user has explicitly disabled bulk loading
+        return () => Promise.resolve(null)
+    }
+
     if (!(await hasRangesQuery(queryGraphQL))) {
         // No-op if the instance doesn't support bulk loading
         return () => Promise.resolve(null)

--- a/shared/search/config.ts
+++ b/shared/search/config.ts
@@ -3,7 +3,5 @@ import { BasicCodeIntelligenceSettings } from './settings'
 
 /** Retrieves a config value by key. */
 export function getConfig<T>(key: string, defaultValue: T): T {
-    const configuredValue = sourcegraph.configuration.get<BasicCodeIntelligenceSettings>().get(key)
-
-    return configuredValue || defaultValue
+    return (sourcegraph.configuration.get<BasicCodeIntelligenceSettings>().get(key) as T | undefined) || defaultValue
 }

--- a/shared/search/settings.ts
+++ b/shared/search/settings.ts
@@ -30,5 +30,5 @@ export interface BasicCodeIntelligenceSettings {
      * The timeout (in milliseconds) for un-indexed search requests.
      */
     'basicCodeIntel.unindexedSearchTimeout'?: number
-    [k: string]: any
+    [k: string]: unknown
 }

--- a/shared/search/settings.ts
+++ b/shared/search/settings.ts
@@ -11,6 +11,10 @@ export interface BasicCodeIntelligenceSettings {
      */
     'codeIntel.lsif'?: boolean
     /**
+     * Whether to fetch multiple precise definitions and references on hover.
+     */
+    'codeIntel.disableRangeQueries'?: boolean
+    /**
      * Whether to include forked repositories in search results.
      */
     'basicCodeIntel.includeForks'?: boolean


### PR DESCRIPTION
Adding `"codeIntel.disableRangeQueries": true` to user settings now disables range queries, which can be very expensive in older instances. I'm adding this to direct pre-3.20 customers with certain poorly performing range queries as a workaround until they can upgrade.