### PR TITLE
WIP PR: For discussion

### DIFF
--- a/extensions/template/src/extension.ts
+++ b/extensions/template/src/extension.ts
@@ -1,18 +1,7 @@
+import { from, Observable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
-import { activateCodeIntel } from '../../../shared/activate'
-import { languageSpecs } from '../../../shared/language-specs/languages'
-import { LanguageSpec } from '../../../shared/language-specs/spec'
-import { languageID } from './language'
-
-/**
- * The set of languages that are actively served by this extension. This
- * will be exactly one language once published, but will be all languages
- * when being run in development mode.
- *
- * The constant in `language.ts` is updated by the generation/publish flow.
- */
-const activeLanguageSpecs =
-    languageID === 'all' ? languageSpecs : languageSpecs.filter(spec => spec.languageID === languageID)
+import { API } from '../../../shared/util/api'
+import { parseGitURI } from '../../../shared/util/uri'
 
 /**
  * Register providers on the extension host.
@@ -20,19 +9,21 @@ const activeLanguageSpecs =
  * @param ctx The extension context.
  */
 export async function activate(context: sourcegraph.ExtensionContext): Promise<void> {
-    await Promise.all(activeLanguageSpecs.map(spec => activateSpec(spec, context)))
-}
+    const api = new API()
 
-/**
- * Register providers on the extension host for the given language spec.
- *
- * @param spec The language spec.
- * @param ctx The extension context.
- */
-function activateSpec(spec: LanguageSpec, context: sourcegraph.ExtensionContext): Promise<void> {
-    return activateCodeIntel(context, spec.fileExts.flatMap(createSelector), spec)
-}
+    const testFileContent = async (textDocument: sourcegraph.TextDocument) => {
+        const { uri, text } = textDocument
+        const { repo, commit, path } = parseGitURI(new URL(uri))
 
-function createSelector(extension: string): sourcegraph.DocumentSelector {
-    return [{ pattern: `*.${extension}` }]
+        if (text && text !== await api.getFileContent(repo, commit, path)) {
+            console.log('textDocument.text=', text)
+        }
+    }
+
+    context.subscriptions.add(
+        sourcegraph.languages.registerDefinitionProvider([{ pattern: '*.go' }], {
+            provideDefinition: (doc: sourcegraph.TextDocument): Observable<sourcegraph.Definition> =>
+                from(testFileContent(doc).then(() => null)),
+        })
+    )
 }


### PR DESCRIPTION
Instructions to reproduce possible extension host error:

- Pull this branch and sideload the template extension
- Go to a repository without LSIF enabled and open the console
- Navigate between files in the same subdirectory and hover over something in each one

You should see console log statements with `path`, `text`, and `textDocument.text`. The first and last properties are the current textDocument attributes. `text` is the text of that path from the GraphQL API. Logs will only emit when the text fields are not equivalent (and textDocument.text is also defined - sometimes its not).

This behavior is triggered when trying to determine the text under the current cursor position, for which the source text is needed.