### PR TITLE
Add typeRoots to tsconfig to allow building inside of a parent project

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "rootDir": ".",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "typeRoots": ["./node_modules/@types"],
   },
   "include": [],
 }


### PR DESCRIPTION
**Background**:

In the Firefox add-on, we bundle extensions into the build. To do this, the build script (which lives in `sourcegraph/sourcegraph`) fetches the `code-intel-extensions` repo and builds extensions from it (currently it actually builds only the `template` extension).

**The problem**

Ideally we want the build process to fetch `code-intel-extensions` into a sub-directory within the root of `sourcegraph/sourcegraph` where the build happens. The problem is that the TS compiler searches up the tree when it looks for type definition files. So when building `code-intel-extensions` within a sub-directory of `sourcegraph/sourcegraph`, it finds the parent project's type definitions and it fails to build because those definitions are conflicting.

**Proposed solution**

Add a value for `typeRoots` in `tsconfig.json` that tells the TS compiler to look for types within its own `node_modules/@types` directory, and prevents it from searching up the tree.

**Alternatives considered**

I considered two other workarounds which are non-ideal:

- Fetch and build `code-intel-extensions` into a system temp directory. The problem is that we also need to produce a source code zip file of both `sourcegraph/sourcegraph` and `code-intel-extensions` together, using a temp directory is an obstacle for that.
- Fetch and build `code-intel-extensions` into a sibling directory. I don't like this because it violates the expectation that running commands inside of a project should only affect the contents of the directory.