### PR TITLE
Update doc links to the new doc schema

### DIFF
--- a/extensions/go/README.md
+++ b/extensions/go/README.md
@@ -28,7 +28,7 @@ This extension adds the same features to code files and diffs on your code host 
 
 ## Basic code intelligence
 
-This extension comes with built-in code intelligence provided by [search-based heuristics](https://docs.sourcegraph.com/user/code_intelligence/basic_code_intelligence). Because this extension uses text-based heuristics, its definition and reference results are not precise:
+This extension comes with built-in code intelligence provided by [search-based heuristics](https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence). Because this extension uses text-based heuristics, its definition and reference results are not precise:
 
 - "Go to definition" on a token goes to the definition found by [universal-ctags](https://github.com/universal-ctags/ctags), a cross-language parsing suite.
 - "Find references" on a token finds all instances of token (with the same case) in the current repository and other repositories.
@@ -60,7 +60,7 @@ For organizations that organize code in a monorepo, it may never be useful to pe
 
 ## LSIF
 
-To enable [LSIF support](https://docs.sourcegraph.com/user/code_intelligence/lsif), add these to your Sourcegraph global settings:
+To enable [LSIF support](https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence), add these to your Sourcegraph global settings:
 
 ```json
   "codeIntel.lsif": true

--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -77,7 +77,7 @@
       "additionalProperties": false,
       "properties": {
         "codeIntel.lsif": {
-          "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
+          "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.",
           "type": "boolean"
         },
         "codeIntel.disableRangeQueries": {

--- a/extensions/go/src/settings.ts
+++ b/extensions/go/src/settings.ts
@@ -7,7 +7,7 @@
 
 export interface Settings {
     /**
-     * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.
+     * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.
      */
     'codeIntel.lsif'?: boolean
     /**

--- a/extensions/template/README.md
+++ b/extensions/template/README.md
@@ -30,7 +30,7 @@ This extension adds the same features to code files and diffs on your code host 
 
 ## Basic code intelligence
 
-This extension comes with built-in code intelligence provided by [search-based heuristics](https://docs.sourcegraph.com/user/code_intelligence/basic_code_intelligence). Because this extension uses text-based heuristics, its definition and reference results are not precise:
+This extension comes with built-in code intelligence provided by [search-based heuristics](https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence). Because this extension uses text-based heuristics, its definition and reference results are not precise:
 
 - "Go to definition" on a token goes to the definition found by [universal-ctags](https://github.com/universal-ctags/ctags), a cross-language parsing suite.
 - "Find references" on a token finds all instances of token (with the same case) in the current repository and other repositories.
@@ -62,7 +62,7 @@ For organizations that organize code in a monorepo, it may never be useful to pe
 
 ## LSIF
 
-To enable [LSIF support](https://docs.sourcegraph.com/user/code_intelligence/lsif), add these to your Sourcegraph global settings:
+To enable [LSIF support](https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence), add these to your Sourcegraph global settings:
 
 ```json
   "codeIntel.lsif": true

--- a/extensions/template/package.json
+++ b/extensions/template/package.json
@@ -47,7 +47,7 @@
       "title": "Basic code intelligence settings",
       "properties": {
         "codeIntel.lsif": {
-          "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
+          "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.",
           "type": "boolean"
         },
         "codeIntel.disableRangeQueries": {

--- a/extensions/typescript/README.md
+++ b/extensions/typescript/README.md
@@ -28,7 +28,7 @@ This extension adds the same features to code files and diffs on your code host 
 
 ## Basic code intelligence
 
-This extension comes with built-in code intelligence provided by [search-based heuristics](https://docs.sourcegraph.com/user/code_intelligence/basic_code_intelligence). Because this extension uses text-based heuristics, its definition and reference results are not precise:
+This extension comes with built-in code intelligence provided by [search-based heuristics](https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence). Because this extension uses text-based heuristics, its definition and reference results are not precise:
 
 - "Go to definition" on a token goes to the definition found by [universal-ctags](https://github.com/universal-ctags/ctags), a cross-language parsing suite.
 - "Find references" on a token finds all instances of token (with the same case) in the current repository and other repositories.
@@ -60,7 +60,7 @@ For organizations that organize code in a monorepo, it may never be useful to pe
 
 ## LSIF
 
-To enable [LSIF support](https://docs.sourcegraph.com/user/code_intelligence/lsif), add these to your Sourcegraph global settings:
+To enable [LSIF support](https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence), add these to your Sourcegraph global settings:
 
 ```json
   "codeIntel.lsif": true

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -81,7 +81,7 @@
       "additionalProperties": false,
       "properties": {
         "codeIntel.lsif": {
-          "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.",
+          "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.",
           "type": "boolean"
         },
         "codeIntel.disableRangeQueries": {

--- a/extensions/typescript/src/settings.ts
+++ b/extensions/typescript/src/settings.ts
@@ -7,7 +7,7 @@
 
 export interface Settings {
     /**
-     * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.
+     * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.
      */
     'codeIntel.lsif'?: boolean
     /**

--- a/shared/badges.ts
+++ b/shared/badges.ts
@@ -67,5 +67,5 @@ export const impreciseBadge: sourcegraph.BadgeAttachmentRenderOptions = {
     light: { icon: makeInfoIcon('#000000') },
     hoverMessage:
         'Search-based results - click to see how these results are calculated and how to get precise intelligence with LSIF.',
-    linkURL: 'https://docs.sourcegraph.com/user/code_intelligence/basic_code_intelligence',
+    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence',
 }

--- a/shared/hover-alerts.ts
+++ b/shared/hover-alerts.ts
@@ -1,6 +1,6 @@
 import * as sourcegraph from 'sourcegraph'
 
-const linkURL = 'https://docs.sourcegraph.com/user/code_intelligence/precise_code_intelligence'
+const linkURL = 'https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence'
 
 function makeSummary(message: string, ctaMessage: string): sourcegraph.MarkupContent {
     return { kind: sourcegraph.MarkupKind.Markdown, value: `${message} [${ctaMessage}](${linkURL})` }

--- a/shared/search/settings.ts
+++ b/shared/search/settings.ts
@@ -7,7 +7,7 @@
 
 export interface BasicCodeIntelligenceSettings {
     /**
-     * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/user/code_intelligence/lsif.
+     * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.
      */
     'codeIntel.lsif'?: boolean
     /**


### PR DESCRIPTION
I noticed this when I clicked on the info link in this hover:

![image](https://user-images.githubusercontent.com/229984/96941442-496db880-1487-11eb-9bb0-121ff2f02bdd.png)

It pointed to https://docs.sourcegraph.com/user/code_intelligence/explanations/precise_code_intelligence, which no longer exists.

This is exacerbated by some missing redirects in our doc site, which I'm going to open a PR for in https://github.com/sourcegraph/sourcegraph, but we should obviously fix this in _all the places_. :broom: