### PR TITLE
Add telemetry events for cross-repo

### DIFF
--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -3,7 +3,7 @@ import { from, Observable, isObservable } from 'rxjs'
 import { take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { FilterDefinitions, LanguageSpec } from '../language-specs/spec'
-import { Providers, SourcegraphProviders } from '../providers'
+import { Providers } from '../providers'
 import { API, RepoMeta } from '../util/api'
 import { asArray, isDefined } from '../util/helpers'
 import { asyncGeneratorFromPromise, cachePromiseProvider } from '../util/ix'
@@ -36,7 +36,7 @@ export function createProviders(
         identCharPattern,
         filterDefinitions = results => results,
     }: LanguageSpec,
-    wrappedProviders: Partial<SourcegraphProviders>,
+    wrappedProviders: { definition?: sourcegraph.DefinitionProvider },
     api: API = new API()
 ): Providers {
     /** Small never-evict map from repo names to their meta. */

--- a/shared/telemetry.ts
+++ b/shared/telemetry.ts
@@ -8,11 +8,13 @@ import * as sourcegraph from 'sourcegraph'
 export class TelemetryEmitter {
     private languageID: string
     private started: number
+    private enabled: boolean
     private emitted = new Set<string>()
 
-    constructor(languageID: string) {
+    constructor(languageID: string, enabled = true) {
         this.languageID = languageID
         this.started = Date.now()
+        this.enabled = enabled
     }
 
     /**
@@ -32,6 +34,10 @@ export class TelemetryEmitter {
      * Emit a telemetry event with durationMs and languageId attributes.
      */
     public async emit(action: string, args: object = {}): Promise<void> {
+        if (!this.enabled) {
+            return
+        }
+
         try {
             await sourcegraph.commands.executeCommand('logTelemetryEvent', `codeintel.${action}`, {
                 ...args,


### PR DESCRIPTION
Emit an additional `{event}.xrepo` each time a def or ref `{event}` would be emitted and that result set contains the first repository-external result seen for this request.

This also reduces some duplicate events: we call definitions from inside hover, which used to cause two definition events and one hover event per user action. It now only emit unique events (not cached events used for hover).

This should collect the data necessary for https://github.com/sourcegraph/sourcegraph/issues/14120.