### PR TITLE
Do not rely on textDocument.text

### DIFF
--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -71,9 +71,8 @@ export function createProviders(
             // Remove a random entry from map. This saves us from having to
             // keep track of frequency or recency information and is likely
             // to be a decent heuristic (with rare back-to-back evictions).
-            cachedFileContents.delete(
-                Array.from(cachedFileContents.keys())[Math.floor(Math.random() * cachedFileContents.size)]
-            )
+            const index = Math.floor(Math.random() * cachedFileContents.size)
+            cachedFileContents.delete([...cachedFileContents.keys()][index])
         }
 
         const { repo, commit, path } = parseGitURI(new URL(uri))


### PR DESCRIPTION
This field is unreliable, as shown in https://github.com/sourcegraph/sourcegraph/issues/15600. We will simply stop using it by always hitting the API for fresh document data. This may be wasteful, but we need to ensure that we don't exhibit weird behavior for older instances as well, and the text document cache should relieve the extra requests.