### PR TITLE
Do not make a search request for tokens that are in strings or comments

### DIFF
--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -104,7 +104,7 @@ export function createProviders(
             lineRegexes: commentStyles.map(style => style.lineRegex).filter(isDefined),
             identCharPattern,
         })
-        if (!tokenResult || tokenResult.isComment) {
+        if (!tokenResult || tokenResult.isString || tokenResult.isComment) {
             return undefined
         }
 

--- a/shared/search/providers.ts
+++ b/shared/search/providers.ts
@@ -102,6 +102,7 @@ export function createProviders(
             text,
             position,
             lineRegexes: commentStyles.map(style => style.lineRegex).filter(isDefined),
+            blockCommentStyles: commentStyles.map(style => style.block).filter(isDefined),
             identCharPattern,
         })
         if (!tokenResult || tokenResult.isString || tokenResult.isComment) {

--- a/shared/search/tokens.test.ts
+++ b/shared/search/tokens.test.ts
@@ -13,6 +13,7 @@ describe('findSearchToken', () => {
             }),
             {
                 searchToken: 'skip-ws!',
+                isString: false,
                 isComment: false,
             }
         )
@@ -27,6 +28,7 @@ describe('findSearchToken', () => {
             }),
             {
                 searchToken: 'bar',
+                isString: false,
                 isComment: false,
             }
         )
@@ -41,6 +43,7 @@ describe('findSearchToken', () => {
             }),
             {
                 searchToken: 'bar',
+                isString: false,
                 isComment: true,
             }
         )
@@ -55,6 +58,7 @@ describe('findSearchToken', () => {
             }),
             {
                 searchToken: 'bar',
+                isString: false,
                 isComment: false,
             }
         )
@@ -69,6 +73,7 @@ describe('findSearchToken', () => {
             }),
             {
                 searchToken: 'bar',
+                isString: false,
                 isComment: false,
             }
         )
@@ -83,6 +88,7 @@ describe('findSearchToken', () => {
             }),
             {
                 searchToken: 'bar',
+                isString: false,
                 isComment: false,
             }
         )
@@ -97,6 +103,7 @@ describe('findSearchToken', () => {
             }),
             {
                 searchToken: 'bar',
+                isString: false,
                 isComment: true,
             }
         )

--- a/shared/search/tokens.test.ts
+++ b/shared/search/tokens.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { slashPattern } from '../language-specs/comments'
+import { cStyleBlockComment, slashPattern } from '../language-specs/comments'
 import { findSearchToken } from './tokens'
 
 describe('findSearchToken', () => {
@@ -9,6 +9,7 @@ describe('findSearchToken', () => {
                 text: '(defn skip-ws! []',
                 position: { line: 0, character: 6 },
                 lineRegexes: [],
+                blockCommentStyles: [],
                 identCharPattern: /[\w!?-]/,
             }),
             {
@@ -25,6 +26,7 @@ describe('findSearchToken', () => {
                 text: 'foo bar // baz',
                 position: { line: 0, character: 5 },
                 lineRegexes: [slashPattern],
+                blockCommentStyles: [],
             }),
             {
                 searchToken: 'bar',
@@ -40,6 +42,7 @@ describe('findSearchToken', () => {
                 text: 'foo // bar baz',
                 position: { line: 0, character: 8 },
                 lineRegexes: [slashPattern],
+                blockCommentStyles: [],
             }),
             {
                 searchToken: 'bar',
@@ -55,6 +58,7 @@ describe('findSearchToken', () => {
                 text: 'foo // bar(baz)',
                 position: { line: 0, character: 8 },
                 lineRegexes: [slashPattern],
+                blockCommentStyles: [],
             }),
             {
                 searchToken: 'bar',
@@ -70,6 +74,7 @@ describe('findSearchToken', () => {
                 text: 'foo // .bar baz',
                 position: { line: 0, character: 9 },
                 lineRegexes: [slashPattern],
+                blockCommentStyles: [],
             }),
             {
                 searchToken: 'bar',
@@ -79,32 +84,144 @@ describe('findSearchToken', () => {
         )
     })
 
-    it('special-cases comment content that looks like a string', () => {
+    it('identifies disjoint block comments after the token', () => {
         assert.deepStrictEqual(
             findSearchToken({
-                text: 'foo // "bar" baz',
-                position: { line: 0, character: 9 },
-                lineRegexes: [slashPattern],
+                text: 'foo /* bar baz */',
+                position: { line: 0, character: 1 },
+                lineRegexes: [],
+                blockCommentStyles: [cStyleBlockComment],
             }),
             {
-                searchToken: 'bar',
+                searchToken: 'foo',
                 isString: false,
                 isComment: false,
             }
         )
     })
 
-    it('special-cases comment content that looks EXACTLY like a string', () => {
+    it('identifies disjoint block comments before the token', () => {
         assert.deepStrictEqual(
             findSearchToken({
-                text: 'foo // "bar baz"',
-                position: { line: 0, character: 9 },
-                lineRegexes: [slashPattern],
+                text: '/* foo bar */ baz',
+                position: { line: 0, character: 15 },
+                lineRegexes: [],
+                blockCommentStyles: [cStyleBlockComment],
+            }),
+            {
+                searchToken: 'baz',
+                isString: false,
+                isComment: false,
+            }
+        )
+    })
+
+    it('identifies block comments on same line', () => {
+        assert.deepStrictEqual(
+            findSearchToken({
+                text: 'foo /* bar */ baz',
+                position: { line: 0, character: 8 },
+                lineRegexes: [],
+                blockCommentStyles: [cStyleBlockComment],
             }),
             {
                 searchToken: 'bar',
                 isString: false,
                 isComment: true,
+            }
+        )
+    })
+
+    it('identifies disjoint block comments over multiple lines', () => {
+        assert.deepStrictEqual(
+            findSearchToken({
+                text: [
+                    '/* short comment */',
+                    '/* comment on this line',
+                    'extend to the next line */',
+                    '',
+                    'foo bar baz',
+                    '',
+                    "/* another comment that doesn't close",
+                ].join('\n`'),
+                position: { line: 4, character: 5 },
+                lineRegexes: [],
+                blockCommentStyles: [cStyleBlockComment],
+            }),
+            {
+                searchToken: 'bar',
+                isString: false,
+                isComment: false,
+            }
+        )
+
+        assert.deepStrictEqual(
+            findSearchToken({
+                text: [
+                    'comment with no opening */',
+                    '/* another short comment */',
+                    '',
+                    'foo bar baz',
+                    '',
+                    '/* comment on this line',
+                    'extend to the next line */',
+                ].join('\n`'),
+                position: { line: 3, character: 5 },
+                lineRegexes: [],
+                blockCommentStyles: [cStyleBlockComment],
+            }),
+            {
+                searchToken: 'bar',
+                isString: false,
+                isComment: false,
+            }
+        )
+    })
+
+    it('identifies block comments over multiple lines', () => {
+        assert.deepStrictEqual(
+            findSearchToken({
+                text: ['/*', 'comment', 'foo bar baz', 'comment', '*/'].join('\n`'),
+                position: { line: 2, character: 5 },
+                lineRegexes: [],
+                blockCommentStyles: [cStyleBlockComment],
+            }),
+            {
+                searchToken: 'bar',
+                isString: false,
+                isComment: true,
+            }
+        )
+    })
+
+    it('identifies strings around the token', () => {
+        assert.deepStrictEqual(
+            findSearchToken({
+                text: '"foo" + bar + \'baz\'',
+                position: { line: 0, character: 9 },
+                lineRegexes: [slashPattern],
+                blockCommentStyles: [],
+            }),
+            {
+                searchToken: 'bar',
+                isString: false,
+                isComment: false,
+            }
+        )
+    })
+
+    it('identifies strings contents', () => {
+        assert.deepStrictEqual(
+            findSearchToken({
+                text: 'foo + "bar" + baz',
+                position: { line: 0, character: 8 },
+                lineRegexes: [slashPattern],
+                blockCommentStyles: [],
+            }),
+            {
+                searchToken: 'bar',
+                isString: true,
+                isComment: false,
             }
         )
     })

--- a/shared/search/tokens.ts
+++ b/shared/search/tokens.ts
@@ -1,3 +1,6 @@
+import { flatten } from 'lodash'
+import { BlockCommentStyle } from '../language-specs/spec'
+
 /**
  * The default regex for characters allowed in an identifier. It works well for
  * C-like languages (C/C++, C#, Java, etc.) but not for languages that allow
@@ -16,18 +19,22 @@ export function findSearchToken({
     text,
     position,
     lineRegexes,
+    blockCommentStyles,
     identCharPattern = DEFAULT_IDENT_CHAR_PATTERN,
 }: {
     /** The text of the current document. */
     text: string
     /** The current hover position. */
     position: { line: number; character: number }
-    /** The pattern that identifies a line comment. */
+    /** The patterns that identify line comments. */
     lineRegexes: RegExp[]
+    /** The patterns that identify block comments. */
+    blockCommentStyles: BlockCommentStyle[]
     /** The pattern that identifies identifiers in this language. */
     identCharPattern?: RegExp
-}): { searchToken: string; isString: boolean, isComment: boolean } | undefined {
-    const line = text.split('\n')[position.line]
+}): { searchToken: string; isString: boolean; isComment: boolean } | undefined {
+    const lines = text.split('\n')
+    const line = lines[position.line]
     if (line === undefined) {
         // Weird case where the position is bogus relative to the text
         return undefined
@@ -61,10 +68,101 @@ export function findSearchToken({
         return undefined
     }
 
-    const searchToken = line.slice(start, end)
+    return {
+        searchToken: line.slice(start, end),
+        isString: isInsideString({ line: lines[position.line], start, end }),
+        isComment: isInsideComment({ lines, position, start, end, lineRegexes, blockCommentStyles }),
+    }
+}
 
+/**
+ * Determine if the identifier matched on the given line occurs within a string.
+ *
+ * @param args Parameter bag.
+ */
+function isInsideString({
+    line,
+    start,
+    end,
+}: {
+    /** The line containing the identifier */
+    line: string
+    /** The offset of the identifier in the target line. */
+    start: number
+    /** The offset and length of the identifier in the target line. */
+    end: number
+}): boolean {
+    return checkMatchIntersection([...line.matchAll(/'.*?'|".*?"/gs)], { start, end })
+}
+
+/**
+ * Determine if the identifier matched on the given line occurs within a comment
+ * defined by the given line comment and block comment regular expressions.
+ *
+ * @param args Parameter bag.
+ */
+function isInsideComment({
+    lines,
+    position,
+    start,
+    end,
+    blockCommentStyles,
+    lineRegexes,
+}: {
+    /** The text of the current document split into lines. */
+    lines: string[]
+    /** The current hover position. */
+    position: { line: number }
+    /** The offset of the identifier in the target line. */
+    start: number
+    /** The offset and length of the identifier in the target line. */
+    end: number
+    /** The patterns that identify line comments. */
+    lineRegexes: RegExp[]
+    /** The patterns that identify block comments. */
+    blockCommentStyles: BlockCommentStyle[]
+}): boolean {
+    const line = lines[position.line]
+
+    if (
+        isInsideLineComment({ line, start, lineRegexes }) ||
+        isInsideBlockComment({ lines, position, start, end, blockCommentStyles })
+    ) {
+        const searchToken = lines[position.line].slice(start, end)
+
+        const blessedPatterns = [
+            // looks like a function call
+            new RegExp(`${searchToken}\\(`),
+            // looks like a field projection
+            new RegExp(`\\.${searchToken}`),
+        ]
+
+        return !blessedPatterns.some(pattern => pattern.test(line))
+    }
+
+    return false
+}
+
+/**
+ * Determine if the identifier matched on the given line occurs within a comment
+ * defined by the given line comment regular expressions.
+ *
+ * @param args Parameter bag.
+ */
+function isInsideLineComment({
+    line,
+    start,
+    lineRegexes,
+}: {
+    /** The line containing the identifier */
+    line: string
+    /** The index where the identifier occurs on the line. */
+    start: number
+    /** The patterns that identify line comments. */
+    lineRegexes: RegExp[]
+}): boolean {
     // Determine if the token occurs after a comment on the same line
-    const insideComment = lineRegexes.some(lineRegex => {
+    return lineRegexes.some(lineRegex => {
         const match = line.match(lineRegex)
         if (!match) {
             return false
@@ -72,26 +170,65 @@ export function findSearchToken({
 
         return match?.index !== undefined && match.index < start
     })
+}
 
-    if (!insideComment) {
-        return { searchToken, isString: false, isComment: false }
-    }
+/**
+ * How many lines of context to capture on each side of a identifier when checking
+ * whether or not the user is within a comment. A value of 50 will search over 101
+ * lines in total.
+ */
+const LINES_OF_CONTEXT = 50
 
-    const blessedPatterns = [
-        // looks like a function call
-        new RegExp(`${searchToken}\\(`),
-        // looks like a field projection
-        new RegExp(`\\.${searchToken}`),
-        // looks like it's exactly the content of a string
-        new RegExp(`('|"|\`)${searchToken}('|"|\`)`),
-    ]
+/**
+ * Determine if the identifier matched on the given line occurs within a comment
+ * defined by the given line block comment style.
+ *
+ * @param args Parameter bag.
+ */
+function isInsideBlockComment({
+    lines,
+    position,
+    start,
+    end,
+    blockCommentStyles,
+}: {
+    /** The text of the current document split into lines. */
+    lines: string[]
+    /** The current hover position. */
+    position: { line: number }
+    /** The offset of the identifier in the target line. */
+    start: number
+    /** The offset and length of the identifier in the target line. */
+    end: number
+    /** The patterns that identify block comments. */
+    blockCommentStyles: BlockCommentStyle[]
+}): boolean {
+    const line = lines[position.line]
+    const linesBefore = lines.slice(Math.max(position.line - LINES_OF_CONTEXT, 0), position.line)
+    const linesAfter = lines.slice(position.line + 1, position.line + LINES_OF_CONTEXT + 1)
 
-    return {
-        searchToken,
-        isString: false,
-        // Ensure that we don't have a "blessed" case that we shouldn't
-        // count as a comment. These are useful circumstances we do want
-        // to search for such as docstring usages.
-        isComment: !blessedPatterns.some(pattern => pattern.test(line)),
-    }
+    // Search over multiple lines of text covering our identifier
+    const context = flatten([linesBefore, [line], linesAfter]).join('\n')
+
+    // Determine how many characters in the context we skip before landing on our line
+    const offset = linesBefore.reduce((accumulator, line) => accumulator + line.length, 0) + linesBefore.length
+
+    // Match all commented blocks in the given block of text. We know
+    // the range of the target identifier in this text: if it's covered
+    // in a match's range then it is nested inside of a comment.
+    return blockCommentStyles.some(block =>
+        checkMatchIntersection(
+            [...context.matchAll(new RegExp(`${block.startRegex.source}.*?${block.endRegex.source}`, 'gs'))],
+            { start: start + offset, end: end + offset }
+        )
+    )
+}
+
+/**
+ * Determine if any of the matches in the given array cover the given range.
+ */
+function checkMatchIntersection(matches: RegExpMatchArray[], range: { start: number; end: number }): boolean {
+    return matches.some(
+        match => match.index !== undefined && match.index <= range.start && match.index + match[0].length >= range.end
+    )
 }

--- a/shared/search/tokens.ts
+++ b/shared/search/tokens.ts
@@ -26,7 +26,7 @@ export function findSearchToken({
     lineRegexes: RegExp[]
     /** The pattern that identifies identifiers in this language. */
     identCharPattern?: RegExp
-}): { searchToken: string; isComment: boolean } | undefined {
+}): { searchToken: string; isString: boolean, isComment: boolean } | undefined {
     const line = text.split('\n')[position.line]
     if (line === undefined) {
         // Weird case where the position is bogus relative to the text
@@ -74,7 +74,7 @@ export function findSearchToken({
     })
 
     if (!insideComment) {
-        return { searchToken, isComment: false }
+        return { searchToken, isString: false, isComment: false }
     }
 
     const blessedPatterns = [
@@ -88,6 +88,7 @@ export function findSearchToken({
 
     return {
         searchToken,
+        isString: false,
         // Ensure that we don't have a "blessed" case that we shouldn't
         // count as a comment. These are useful circumstances we do want
         // to search for such as docstring usages.


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/17250.

We used to detect the hovered identifier's location as in a comment or not and would skip search results when it was in a comment and wasn't particularly interesting (didn't look like a projection or function call, which could be documented usage).

Now, we detect whether or not the identifier exists in block comments and strings as well. To do this we take the range +/- 50 lines around the hover area and select all text that is surrounded by that language's block comment identifiers. If the identifier exists in one of these matches, it's in a comment and we don't do a search.

Some possible unintended consequence:

- People found navigation into comment text useful (somehow)? I think this is super unlikely, and we've gotten plenty of "bogus results" feedback from weird-looking (to a human) search results.
- There are actual uses of searching in strings (e.g. field['index.thing']), where search results could be useful. We can always add rules for things like "identifiers EXACTLY in a string" or "x.{token}.y" should be matched as it's likely a unique string as we see strange behavior arise.