### PR TITLE
Expand C-family docstring resolution

### DIFF
--- a/shared/language-specs/cpp.ts
+++ b/shared/language-specs/cpp.ts
@@ -48,7 +48,17 @@ export const cppSpec: LanguageSpec = {
         'pc', // Pro-C by Oracle RDBMS
         'pcc', // Pro-C by Oracle RDBMS
     ],
-    commentStyles: [cStyleComment],
+    commentStyles: [
+        {
+            ...cStyleComment,
+            // Ignore identifiers between definition line and doc block. This enables
+            // correctly finding doc strings for function definitions that span multiple
+            // lines (return type and function name separated by a newline). We'll only
+            // enable this for C-family languages as it seems to be the most pervasive
+            // language with this style.
+            ...{ docstringIgnore: /^[\s\w]+/ },
+        },
+    ],
     filterDefinitions,
     lsifSupport: LSIFSupport.Experimental,
 }

--- a/shared/search/docstrings.ts
+++ b/shared/search/docstrings.ts
@@ -179,7 +179,7 @@ function findDocstringInBlockComment({
     docstringIgnore?: RegExp
 }): string[] | undefined {
     // Drop any leading ignored content between the definition and the docstring
-    const cleanLines = dropWhile(lines, line => docstringIgnore?.test(line))
+    const cleanLines = dropWhile(lines, line => docstringIgnore?.test(line) || line.trim() === '')
 
     // Check for starting delimiter
     if (!cleanLines[0] || !startRegex.test(cleanLines[0])) {


### PR DESCRIPTION
**Before**:

<img width="736" alt="Screen Shot 2021-02-03 at 2 38 02 PM" src="https://user-images.githubusercontent.com/103087/106806332-72c4e580-662d-11eb-9950-e11c4a2c6496.png">

**After**:

<img width="798" alt="Screen Shot 2021-02-03 at 2 37 41 PM" src="https://user-images.githubusercontent.com/103087/106806328-72c4e580-662d-11eb-8842-874bdc821428.png">

**Summary**:

Each supported language in these extensions have a set of properties attached to them (file extensions, what identifier patterns look like, what comments look like, etc). One of these properties is `docstringIgnore`, which will allow us to ignore the lines between where a ctags definition occurs and the comment that is meant to belong to it. Until now, all we've used this for is for Java-style annotations, e.g.

```java
/** docstring **/
@MyBigAnnotation
class Something {
    // ...
}
```

This adds support for the C-family convention of breaking definitions up onto multiple lines:

```cpp
/** docstring **/
RET_VALUE
ActualMethod(...) {
    // ...
}
```

This _could_ have unintended side-effects where comments that do not belong to a ctags definition just happens to be close enough to it, but I think it's an acceptable risk tradeoff (while hand-testing I couldn't get it to do something _worse_ than the previous behavior).

Fixes https://github.com/sourcegraph/sourcegraph/issues/17925.