### PR TITLE
Add trace logging

### DIFF
--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -80,6 +80,10 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.",
           "type": "boolean"
         },
+        "codeIntel.traceExtension": {
+          "description": "Whether to enable trace logging on the extension.",
+          "type": "boolean"
+        },
         "codeIntel.disableRangeQueries": {
           "description": "Whether to fetch multiple precise definitions and references on hover.",
           "type": "boolean"

--- a/extensions/go/src/settings.ts
+++ b/extensions/go/src/settings.ts
@@ -11,6 +11,10 @@ export interface Settings {
      */
     'codeIntel.lsif'?: boolean
     /**
+     * Whether to enable trace logging on the extension.
+     */
+    'codeIntel.traceExtension'?: boolean
+    /**
      * Whether to fetch multiple precise definitions and references on hover.
      */
     'codeIntel.disableRangeQueries'?: boolean

--- a/extensions/template/package.json
+++ b/extensions/template/package.json
@@ -50,6 +50,10 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.",
           "type": "boolean"
         },
+        "codeIntel.traceExtension": {
+          "description": "Whether to enable trace logging on the extension.",
+          "type": "boolean"
+        },
         "codeIntel.disableRangeQueries": {
           "description": "Whether to fetch multiple precise definitions and references on hover.",
           "type": "boolean"

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -84,6 +84,10 @@
           "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.",
           "type": "boolean"
         },
+        "codeIntel.traceExtension": {
+          "description": "Whether to enable trace logging on the extension.",
+          "type": "boolean"
+        },
         "codeIntel.disableRangeQueries": {
           "description": "Whether to fetch multiple precise definitions and references on hover.",
           "type": "boolean"

--- a/extensions/typescript/src/settings.ts
+++ b/extensions/typescript/src/settings.ts
@@ -11,6 +11,10 @@ export interface Settings {
      */
     'codeIntel.lsif'?: boolean
     /**
+     * Whether to enable trace logging on the extension.
+     */
+    'codeIntel.traceExtension'?: boolean
+    /**
      * Whether to fetch multiple precise definitions and references on hover.
      */
     'codeIntel.disableRangeQueries'?: boolean

--- a/shared/search/config.ts
+++ b/shared/search/config.ts
@@ -1,7 +1,9 @@
 import * as sourcegraph from 'sourcegraph'
-import { BasicCodeIntelligenceSettings } from './settings'
+import { SearchBasedCodeIntelligenceSettings } from './settings'
 
 /** Retrieves a config value by key. */
 export function getConfig<T>(key: string, defaultValue: T): T {
-    return (sourcegraph.configuration.get<BasicCodeIntelligenceSettings>().get(key) as T | undefined) || defaultValue
+    return (
+        (sourcegraph.configuration.get<SearchBasedCodeIntelligenceSettings>().get(key) as T | undefined) || defaultValue
+    )
 }

--- a/shared/search/settings.ts
+++ b/shared/search/settings.ts
@@ -5,11 +5,15 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export interface BasicCodeIntelligenceSettings {
+export interface SearchBasedCodeIntelligenceSettings {
     /**
      * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.
      */
     'codeIntel.lsif'?: boolean
+    /**
+     * Whether to enable trace logging on the extension.
+     */
+    'codeIntel.traceExtension'?: boolean
     /**
      * Whether to fetch multiple precise definitions and references on hover.
      */


### PR DESCRIPTION
This adds `codeIntel.traceExtension` setting, which will log the set of results it send back to the extension host for definition, reference, and hover requests.