### PR TITLE
Do not block on telemetry

### DIFF
--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -364,11 +364,11 @@ async function logLocationResults<T extends sourcegraph.Badged<sourcegraph.Locat
     emitter?: TelemetryEmitter
     logger?: Logger
 }): Promise<void> {
-    await emitter?.emitOnce(action)
+    emitter?.emitOnce(action)
 
     // Emit xrepo event if we contain a result from another repository
     if (asArray(results).some(location => parseGitURI(location.uri).repo !== repo)) {
-        await emitter?.emitOnce(action + '.xrepo')
+        emitter?.emitOnce(action + '.xrepo')
     }
 
     if (logger) {
@@ -456,7 +456,7 @@ export function createHoverProvider(
                     }
                 }
 
-                await emitter.emitOnce('lsifHover')
+                emitter.emitOnce('lsifHover')
                 logger?.log({ provider: 'hover', precise: true, ...commonLogFields })
                 yield badgeHoverResult(
                     lsifWrapper.hover,
@@ -479,7 +479,7 @@ export function createHoverProvider(
                         continue
                     }
 
-                    const first = await emitter.emitOnce('lspHover')
+                    const first = emitter.emitOnce('lspHover')
                     logger?.log({ provider: 'hover', precise: true, ...commonLogFields })
                     yield badgeHoverResult(
                         lspResult,
@@ -503,7 +503,7 @@ export function createHoverProvider(
                     continue
                 }
 
-                const first = await emitter.emitOnce('searchHover')
+                const first = emitter.emitOnce('searchHover')
                 logger?.log({ provider: 'hover', precise: false, ...commonLogFields })
 
                 if (hasPreciseDefinition) {
@@ -552,7 +552,7 @@ export function createDocumentHighlightProvider(
 
             for await (const lsifResult of lsifProvider(textDocument, position)) {
                 if (lsifResult) {
-                    await emitter.emitOnce('lsifDocumentHighlight')
+                    emitter.emitOnce('lsifDocumentHighlight')
                     yield lsifResult
                 }
             }

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -207,7 +207,7 @@ export function createDefinitionProvider(
                 // Mark new results as precise
                 const aggregableBadges = [indicators.semanticBadge]
                 const results = { ...rawResults, aggregableBadges }
-                await logLocationResults({ ...commonFields, action: 'lsifDefinitions', results })
+                logLocationResults({ ...commonFields, action: 'lsifDefinitions', results })
                 yield results
                 hasPreciseResult = true
             }
@@ -224,7 +224,7 @@ export function createDefinitionProvider(
                         continue
                     }
 
-                    await logLocationResults({ ...commonFields, action: 'lspDefinitions', results })
+                    logLocationResults({ ...commonFields, action: 'lspDefinitions', results })
                     yield results
                     hasPreciseResult = true
                 }
@@ -250,7 +250,7 @@ export function createDefinitionProvider(
                 const badge = indicators.impreciseBadge
                 const aggregableBadges = [indicators.searchBasedBadge]
                 const results = mapArrayish(rawResult, location => ({ ...location, badge, aggregableBadges }))
-                await logLocationResults({ ...commonFields, action: 'searchDefinitions', results })
+                logLocationResults({ ...commonFields, action: 'searchDefinitions', results })
                 yield results
             }
         }),
@@ -296,7 +296,7 @@ export function createReferencesProvider(
                 // Mark results as precise
                 const aggregableBadges = [indicators.semanticBadge]
                 lsifResults = asArray(rawResult).map(location => ({ ...location, aggregableBadges }))
-                await logLocationResults({ ...commonFields, action: 'lsifReferences', results: lsifResults })
+                logLocationResults({ ...commonFields, action: 'lsifReferences', results: lsifResults })
                 yield lsifResults
             }
 
@@ -310,7 +310,7 @@ export function createReferencesProvider(
                     // Re-emit the last results from the previous provider so that we do not overwrite
                     // what was emitted previously.
                     const results = lsifResults.concat(lspResults)
-                    await logLocationResults({ ...commonFields, action: 'lspReferences', results })
+                    logLocationResults({ ...commonFields, action: 'lspReferences', results })
                     yield results
                 }
 
@@ -337,7 +337,7 @@ export function createReferencesProvider(
                 const results = lsifResults.concat(
                     searchResults.map(location => ({ ...location, badge, aggregableBadges }))
                 )
-                await logLocationResults({ ...commonFields, action: 'searchReferences', results })
+                logLocationResults({ ...commonFields, action: 'searchReferences', results })
                 yield results
             }
         }),
@@ -345,7 +345,7 @@ export function createReferencesProvider(
 }
 
 /** logLocationResults emits telemetry events and emits location counts to the debug logger. */
-async function logLocationResults<T extends sourcegraph.Badged<sourcegraph.Location>, R extends T | T[] | null>({
+function logLocationResults<T extends sourcegraph.Badged<sourcegraph.Location>, R extends T | T[] | null>({
     provider,
     action,
     repo,
@@ -363,7 +363,7 @@ async function logLocationResults<T extends sourcegraph.Badged<sourcegraph.Locat
     results: R
     emitter?: TelemetryEmitter
     logger?: Logger
-}): Promise<void> {
+}): void {
     emitter?.emitOnce(action)
 
     // Emit xrepo event if we contain a result from another repository

--- a/shared/telemetry.ts
+++ b/shared/telemetry.ts
@@ -22,13 +22,14 @@ export class TelemetryEmitter {
      * same action has not yet emitted for this instance. This method
      * returns true if an event was emitted and false otherwise.
      */
-    public emitOnce(action: string, args: object = {}): Promise<boolean> {
+    public emitOnce(action: string, args: object = {}): boolean {
         if (this.emitted.has(action)) {
-            return Promise.resolve(false)
+            return false
         }
 
         this.emitted.add(action)
-        return this.emit(action, args).then(() => true)
+        this.emit(action, args).catch(error => console.error(error))
+        return true
     }
 
     /**


### PR DESCRIPTION
This makes the `emitOnce` function something that will fire-and-forget the telemetry requests so that a long write to the event logs table or a network failure does not blow up the user experience.