### PR TITLE
Add commit to manifest

### DIFF
--- a/dev/scripts/generate.ts
+++ b/dev/scripts/generate.ts
@@ -3,6 +3,10 @@ import * as fs from 'mz/fs'
 import * as path from 'path'
 import { LanguageSpec } from '../../shared/language-specs/spec'
 import { findLanguageSpecs } from './args'
+import { exec as _exec } from 'child_process'
+import { promisify } from 'util'
+
+const exec = promisify(_exec)
 
 async function main(): Promise<void> {
     const specs = findLanguageSpecs()
@@ -39,6 +43,7 @@ async function generate({ languageID, stylized }: LanguageSpec): Promise<void> {
                 description: `Provides search-based code intelligence for ${stylized} using the Sourcegraph search API`,
                 activationEvents: [`onLanguage:${languageID}`],
                 icon: `data:image/png;base64,${(await fs.readFile(iconFilename)).toString('base64')}`,
+                commit: (await exec('git rev-parse head')).stdout.trimEnd(),
             },
             null,
             2


### PR DESCRIPTION
In order to help customers with a private extension registry triage, we need to know what version they have synced. Right now we only have a date that they synced, from which it is a bit clunky to find a commit.

This adds the commit directly to the manifest so we can ask them for the exact version of code they are running.