### PR TITLE
Remove use of ioutil package

### DIFF
--- a/dev/extract-ctags/main.go
+++ b/dev/extract-ctags/main.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -175,7 +174,7 @@ func knownLanguages(path string) (map[string]bool, error) {
 	if path == "" {
 		return nil, nil // OK, don't filter
 	}
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)