### PR TITLE
Populate ranges (for codeintellify) for range-resolved hovers

### DIFF
--- a/shared/lsif/ranges.ts
+++ b/shared/lsif/ranges.ts
@@ -315,6 +315,16 @@ const rangesQuery = gql`
                                     markdown {
                                         text
                                     }
+                                    range {
+                                        start {
+                                            line
+                                            character
+                                        }
+                                        end {
+                                            line
+                                            character
+                                        }
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Previously we were returning `undefined` for the range field in all hover responses that were resolved via range queries. Hover/definition queries can be resolved in two ways:

- From a ?DefinitionAndHover graphql query that asks for a specific position
- From a ?Ranges query that gives you a bulk window of information about ranges falling between two lines of code

The former would return a span of the currently highlighted identifier. The latter always returned undefined, but should now should return the range associated with that data.