### PR TITLE
bundle repository ID in telemetry event to not depend on url in backend

### DIFF
--- a/extensions/go/src/gddo.test.ts
+++ b/extensions/go/src/gddo.test.ts
@@ -11,6 +11,7 @@ import { API } from '../../../shared/util/api'
 describe('findReposViaGDDO', () => {
     const trimGitHubPrefix = (url: string) =>
         Promise.resolve({
+            id: 5,
             name: url.slice('github.com/'.length),
             isFork: false,
             isArchived: false,

--- a/extensions/typescript/src/package.test.ts
+++ b/extensions/typescript/src/package.test.ts
@@ -7,7 +7,7 @@ describe('resolvePackageRepo', () => {
     it('resolves string repo', async () => {
         const api = new API()
         const mock = sinon.stub(api, 'resolveRepo')
-        mock.callsFake(repo => Promise.resolve({ name: repo, isFork: false, isArchived: false }))
+        mock.callsFake(repo => Promise.resolve({ id: 1, name: repo, isFork: false, isArchived: false }))
         const name = await resolvePackageRepo('{"repository": "foo"}', api)
         assert.equal(name, 'foo')
         sinon.assert.calledWith(mock, 'foo')
@@ -16,7 +16,7 @@ describe('resolvePackageRepo', () => {
     it('resolves repos with url', async () => {
         const api = new API()
         const mock = sinon.stub(api, 'resolveRepo')
-        mock.callsFake(repo => Promise.resolve({ name: repo, isFork: false, isArchived: false }))
+        mock.callsFake(repo => Promise.resolve({ id: 1, name: repo, isFork: false, isArchived: false }))
         const name = await resolvePackageRepo('{"repository": {"url": "foo"}}', api)
         assert.equal(name, 'foo')
         sinon.assert.calledWith(mock, 'foo')
@@ -25,7 +25,7 @@ describe('resolvePackageRepo', () => {
     it('resolves repos without repo field', async () => {
         const api = new API()
         const mock = sinon.stub(api, 'resolveRepo')
-        mock.callsFake(repo => Promise.resolve({ name: repo, isFork: false, isArchived: false }))
+        mock.callsFake(repo => Promise.resolve({ id: 1, name: repo, isFork: false, isArchived: false }))
         const name = await resolvePackageRepo('{}', api)
         assert.equal(name, undefined)
         sinon.assert.notCalled(mock)

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -6,6 +6,7 @@ import { Logger, NoopLogger } from './logging'
 import { createProviders as createLSIFProviders } from './lsif/providers'
 import { createProviders as createSearchProviders } from './search/providers'
 import { TelemetryEmitter } from './telemetry'
+import { API } from './util/api'
 import { asArray, mapArrayish, nonEmpty } from './util/helpers'
 import { noopAsyncGenerator, observableFromAsyncIterator } from './util/ix'
 import { parseGitURI } from './util/uri'
@@ -116,8 +117,9 @@ export class NoopProviderWrapper implements ProviderWrapper {
  */
 export function createProviderWrapper(languageSpec: LanguageSpec, logger: Logger): ProviderWrapper {
     const wrapped: { definition?: sourcegraph.DefinitionProvider } = {}
+    const api = new API()
     const lsifProviders = createLSIFProviders(logger)
-    const searchProviders = createSearchProviders(languageSpec, wrapped)
+    const searchProviders = createSearchProviders(languageSpec, wrapped, api)
 
     const providerLogger =
         sourcegraph.configuration.get().get('codeIntel.traceExtension') ?? false ? console : new NoopLogger()
@@ -136,7 +138,8 @@ export function createProviderWrapper(languageSpec: LanguageSpec, logger: Logger
                 lspProvider,
                 providerLogger,
                 languageSpec.languageID,
-                true
+                true,
+                api
             )
 
             // Return the provider with telemetry to use from the root
@@ -145,7 +148,9 @@ export function createProviderWrapper(languageSpec: LanguageSpec, logger: Logger
                 searchProviders.definition,
                 lspProvider,
                 providerLogger,
-                languageSpec.languageID
+                languageSpec.languageID,
+                false,
+                api
             )
         },
 
@@ -155,7 +160,8 @@ export function createProviderWrapper(languageSpec: LanguageSpec, logger: Logger
                 searchProviders.references,
                 lspProvider,
                 providerLogger,
-                languageSpec.languageID
+                languageSpec.languageID,
+                api
             ),
 
         hover: (lspProvider?: HoverProvider) =>
@@ -166,11 +172,12 @@ export function createProviderWrapper(languageSpec: LanguageSpec, logger: Logger
                 searchProviders.hover,
                 lspProvider,
                 providerLogger,
-                languageSpec.languageID
+                languageSpec.languageID,
+                api
             ),
 
         documentHighlights: () =>
-            createDocumentHighlightProvider(lsifProviders.documentHighlights, logger, languageSpec.languageID),
+            createDocumentHighlightProvider(lsifProviders.documentHighlights, logger, languageSpec.languageID, api),
     }
 }
 
@@ -190,15 +197,17 @@ export function createDefinitionProvider(
     lspProvider?: DefinitionProvider,
     logger?: Logger,
     languageID: string = '',
-    quiet = false
+    quiet = false,
+    api = new API()
 ): sourcegraph.DefinitionProvider {
     return {
         provideDefinition: wrapProvider(async function* (
             textDocument: sourcegraph.TextDocument,
             position: sourcegraph.Position
         ): AsyncGenerator<sourcegraph.Definition | undefined, void, undefined> {
-            const emitter = new TelemetryEmitter(languageID, !quiet)
             const { repo } = parseGitURI(new URL(textDocument.uri))
+            const repoId = (await api.resolveRepo(repo)).id
+            const emitter = new TelemetryEmitter(languageID, repoId, !quiet)
             const commonFields = { provider: 'definition', repo, textDocument, position, emitter, logger }
             const lsifWrapper = await lsifProvider(textDocument, position)
             let hasPreciseResult = false
@@ -275,7 +284,8 @@ export function createReferencesProvider(
     searchProvider: ReferencesProvider,
     lspProvider?: ReferencesProvider,
     logger?: Logger,
-    languageID: string = ''
+    languageID: string = '',
+    api = new API()
 ): sourcegraph.ReferenceProvider {
     return {
         provideReferences: wrapProvider(async function* (
@@ -283,8 +293,9 @@ export function createReferencesProvider(
             position: sourcegraph.Position,
             context: sourcegraph.ReferenceContext
         ): AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
-            const emitter = new TelemetryEmitter(languageID)
             const { repo } = parseGitURI(new URL(textDocument.uri))
+            const repoId = (await api.resolveRepo(repo)).id
+            const emitter = new TelemetryEmitter(languageID, repoId)
             const commonFields = { repo, textDocument, position, emitter, logger, provider: 'references' }
 
             let lsifResults: sourcegraph.Location[] = []
@@ -419,7 +430,8 @@ export function createHoverProvider(
     searchHoverProvider: HoverProvider,
     lspProvider?: HoverProvider,
     logger?: Logger,
-    languageID: string = ''
+    languageID: string = '',
+    api = new API()
 ): sourcegraph.HoverProvider {
     const searchAlerts =
         lsifSupport === LSIFSupport.None
@@ -435,8 +447,9 @@ export function createHoverProvider(
             textDocument: sourcegraph.TextDocument,
             position: sourcegraph.Position
         ): AsyncGenerator<sourcegraph.Badged<sourcegraph.Hover> | null | undefined, void, undefined> {
-            const emitter = new TelemetryEmitter(languageID)
-            const { path } = parseGitURI(new URL(textDocument.uri))
+            const { repo, path } = parseGitURI(new URL(textDocument.uri))
+            const repoId = (await api.resolveRepo(repo)).id
+            const emitter = new TelemetryEmitter(languageID, repoId)
             const commonLogFields = { path, line: position.line, character: position.character }
             const lsifWrapper = await lsifProvider(textDocument, position)
 
@@ -541,14 +554,17 @@ function badgeHoverResult(
 export function createDocumentHighlightProvider(
     lsifProvider: DocumentHighlightProvider,
     logger?: Logger,
-    languageID: string = ''
+    languageID: string = '',
+    api = new API()
 ): sourcegraph.DocumentHighlightProvider {
     return {
         provideDocumentHighlights: wrapProvider(async function* (
             textDocument: sourcegraph.TextDocument,
             position: sourcegraph.Position
         ): AsyncGenerator<sourcegraph.DocumentHighlight[] | null | undefined, void, undefined> {
-            const emitter = new TelemetryEmitter(languageID)
+            const { repo } = parseGitURI(new URL(textDocument.uri))
+            const repoId = (await api.resolveRepo(repo)).id
+            const emitter = new TelemetryEmitter(languageID, repoId)
 
             for await (const lsifResult of lsifProvider(textDocument, position)) {
                 if (lsifResult) {

--- a/shared/search/providers.test.ts
+++ b/shared/search/providers.test.ts
@@ -123,13 +123,15 @@ describe('search providers', () => {
     const newAPIWithStubResolveRepo = ({
         isFork = false,
         isArchived = false,
+        id = 1,
     }: {
         isFork?: boolean
         isArchived?: boolean
+        id?: number
     } = {}): API => {
         const api = new API()
         const stub = sinon.stub(api, 'resolveRepo')
-        stub.callsFake(repo => Promise.resolve({ name: repo, isFork, isArchived }))
+        stub.callsFake(repo => Promise.resolve({ name: repo, isFork, isArchived, id }))
         return api
     }
 

--- a/shared/telemetry.ts
+++ b/shared/telemetry.ts
@@ -7,13 +7,24 @@ import * as sourcegraph from 'sourcegraph'
  */
 export class TelemetryEmitter {
     private languageID: string
+    private repoID: number
     private started: number
     private enabled: boolean
     private emitted = new Set<string>()
 
-    constructor(languageID: string, enabled = true) {
+    /**
+     * Creates a new telemetry emitter object for a given
+     * language ID and repository ID.
+     * Emitting is enabled by default
+     *
+     * @param languageID The language identifier e.g. 'java'.
+     * @param repoID numeric repository identifier.
+     * @param enabled Whether telemetry is enabled.
+     */
+    constructor(languageID: string, repoID: number, enabled = true) {
         this.languageID = languageID
         this.started = Date.now()
+        this.repoID = repoID
         this.enabled = enabled
     }
 
@@ -45,6 +56,7 @@ export class TelemetryEmitter {
                 ...args,
                 durationMs: this.elapsed(),
                 languageId: this.languageID,
+                repositoryId: this.repoID,
             })
         } catch {
             // Older version of Sourcegraph may have not registered this

--- a/shared/util/graphql.ts
+++ b/shared/util/graphql.ts
@@ -1,3 +1,4 @@
+import { fromBase64 } from 'js-base64'
 import * as sourcegraph from 'sourcegraph'
 
 type GraphQLResponse<T> = GraphQLResponseSuccess<T> | GraphQLResponseError
@@ -36,4 +37,9 @@ function aggregateErrors(errors: Error[]): Error {
         name: 'AggregateError',
         errors,
     })
+}
+
+export function graphqlIdToRepoId(id: string): number {
+    const decodedId = fromBase64(id)
+    return parseInt(decodedId.split(':')[1], 10)
 }


### PR DESCRIPTION
As a caching mechanism already existed at a different level, I've moved it lower down to the `API` class so it can be cached for both the search provider and the general code-intel feature providers.

This is part of the work for private code on dotcom, specifically https://github.com/sourcegraph/sourcegraph/issues/20628. The reliance on the `argument` column is still necessary, further discussion can be found on Slack