### PR TITLE
Add line-break to the hover alert message

### DIFF
--- a/shared/indicators.ts
+++ b/shared/indicators.ts
@@ -64,7 +64,7 @@ const makeAlert = ({
         iconKind: 'info',
         summary: {
             kind: sourcegraph.MarkupKind.Markdown,
-            value: `${message} [Learn more about precise code intelligence](${linkURL})`,
+            value: `${message}<br /> [Learn more about precise code intelligence](${linkURL})`,
         },
         ...legacyFields,
     }


### PR DESCRIPTION
A "Learn more about precise code intelligence" link is located on the new line in the [redesigned version](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=3958%3A10) of the hover overlay. This PR adds a required line break.