### PR TITLE
Ensure CI runs lint and tests

### DIFF
--- a/.buildkite/lint.sh
+++ b/.buildkite/lint.sh
@@ -4,4 +4,6 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 yarn --mutex network --frozen-lockfile --network-timeout 60000
-yarn run build eslint prettier-check
+yarn run build
+yarn run eslint
+yarn run prettier-check

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -4,4 +4,6 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 yarn --mutex network --frozen-lockfile --network-timeout 60000
-yarn run build test coverage
+yarn run build
+yarn run test
+yarn run coverage

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,6 @@ module.exports = {
   rules: {
     // [...a] breaks when Array.from(a) works
     // when a is not an array but an iterable
-    "unicorn/prefer-spread": 0
+    'unicorn/prefer-spread': 0,
   },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,9 +5,9 @@ module.exports = {
     node: true,
   },
   parserOptions: {
-    project: ['template/tsconfig.json', 'dev/scripts/tsconfig.json'],
+    project: ['template/tsconfig.json', 'scripts/tsconfig.json'],
   },
-  ignorePatterns: ['generated-*', '**/dist', 'samples'],
+  ignorePatterns: ['generated-*', '**/dist'],
   rules: {
     // [...a] breaks when Array.from(a) works
     // when a is not an array but an iterable

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-generated-*
-temp
-dist
-node_modules
-coverage
 .cache
-.nyc_output/
+.nyc_output
+coverage
+dist
+generated-*
+node_modules
+
 .eslintcache
 yarn-error.log

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,6 @@
-generated-*
-temp
-dist
-node_modules
-coverage
 .cache
-samples
 .nyc_output
+coverage
+dist
+generated-*
+node_modules

--- a/scripts/args.ts
+++ b/scripts/args.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs'
+
 import { languageSpecs } from '../template/src/language-specs/languages'
 import { LanguageSpec } from '../template/src/language-specs/spec'
 

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,7 +1,10 @@
+import * as path from 'path'
+
 import { copy, emptyDir, ensureDir } from 'fs-extra'
 import * as fs from 'mz/fs'
-import * as path from 'path'
+
 import { LanguageSpec } from '../template/src/language-specs/spec'
+
 import { findLanguageSpecs } from './args'
 
 async function main(): Promise<void> {

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -49,7 +49,9 @@ async function generate({ languageID, stylized }: LanguageSpec): Promise<void> {
     // Update README.md placeholders with language name
     await fs.writeFile(
         readmeFilename,
-        (await fs.readFile(readmeFilename))
+        (
+            await fs.readFile(readmeFilename)
+        )
             .toString()
             .replace(/LANG\b/g, stylized)
             .replace(/LANGID\b/g, languageID)

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,5 +1,6 @@
 import * as child_process from 'mz/child_process'
 import * as fs from 'mz/fs'
+
 import { findLanguageSpecs } from './args'
 
 async function main(): Promise<void> {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json",
+}

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -1,8 +1,9 @@
-import * as sourcegraph from 'sourcegraph'
-import { languageSpecs } from './language-specs/languages'
-import { languageID } from './language'
 import { from } from 'rxjs'
 import { distinctUntilChanged, map, startWith } from 'rxjs/operators'
+import * as sourcegraph from 'sourcegraph'
+
+import { languageID } from './language'
+import { languageSpecs } from './language-specs/languages'
 import { LanguageSpec } from './language-specs/spec'
 import { Logger, RedactingLogger } from './logging'
 import { createProviders } from './providers'

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -11,7 +11,7 @@ import { createProviders } from './providers'
 /**
  * Register providers on the extension host.
  *
- * @param ctx The extension context.
+ * @param context The extension context.
  */
 export const activate = (context: sourcegraph.ExtensionContext): void => {
     for (const spec of languageID === 'all'
@@ -40,7 +40,7 @@ const DUMMY_CTX = {
  * Activate the extension by registering definition, reference, and hover providers
  * with LSIF and search-based providers.
  *
- * @param ctx  The extension context.
+ * @param context  The extension context.
  * @param selector The document selector for which this extension is active.
  * @param languageSpec The language spec used to provide search-based code intelligence.
  * @param logger An optional logger instance.

--- a/template/src/init.test.ts
+++ b/template/src/init.test.ts
@@ -1,4 +1,6 @@
+import mock from 'mock-require'
+
 // Stub Sourcegraph API
 import { createStubSourcegraphAPI } from '@sourcegraph/extension-api-stubs'
-import mock from 'mock-require'
+
 mock('sourcegraph', createStubSourcegraphAPI())

--- a/template/src/language-specs/cpp.test.ts
+++ b/template/src/language-specs/cpp.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { cppSpec } from './cpp'
 import { nilFilterContext, nilResult } from './spec.test'
 

--- a/template/src/language-specs/go.test.ts
+++ b/template/src/language-specs/go.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { goSpec } from './go'
 import { nilFilterContext, nilResult } from './spec.test'
 

--- a/template/src/language-specs/go.ts
+++ b/template/src/language-specs/go.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+
 import { slashPattern } from './comments'
 import { FilterContext, LanguageSpec, Result, LSIFSupport } from './spec'
 import { extractFromLines, filterResults } from './util'

--- a/template/src/language-specs/icons.test.ts
+++ b/template/src/language-specs/icons.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert'
-import * as fs from 'mz/fs'
 import * as path from 'path'
+
+import * as fs from 'mz/fs'
+
 import { languageSpecs } from './languages'
 
 describe('all defined languages', () => {

--- a/template/src/language-specs/java.test.ts
+++ b/template/src/language-specs/java.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { javaSpec } from './java'
 import { nilFilterContext, nilResult } from './spec.test'
 

--- a/template/src/language-specs/java.ts
+++ b/template/src/language-specs/java.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+
 import { javaStyleComment } from './comments'
 import { FilterContext, LanguageSpec, Result, LSIFSupport } from './spec'
 import { extractFromLines, filterResultsByImports, slashToDot } from './util'

--- a/template/src/language-specs/python.test.ts
+++ b/template/src/language-specs/python.test.ts
@@ -37,10 +37,10 @@ describe('pythonSpec', () => {
 
 describe('relativeImportPath', () => {
     it('converts relative import to path', () => {
-        assert.equal(relativeImportPath('a/b/c.py', 'foo'), undefined)
-        assert.equal(relativeImportPath('a/b/c.py', '.foo'), 'a/b/foo')
-        assert.equal(relativeImportPath('a/b/c.py', '.foo.bar'), 'a/b/foo/bar')
-        assert.equal(relativeImportPath('a/b/c.py', '..foo.bar'), 'a/foo/bar')
-        assert.equal(relativeImportPath('a/b/c.py', '....foo'), '../foo')
+        assert.strictEqual(relativeImportPath('a/b/c.py', 'foo'), undefined)
+        assert.strictEqual(relativeImportPath('a/b/c.py', '.foo'), 'a/b/foo')
+        assert.strictEqual(relativeImportPath('a/b/c.py', '.foo.bar'), 'a/b/foo/bar')
+        assert.strictEqual(relativeImportPath('a/b/c.py', '..foo.bar'), 'a/foo/bar')
+        assert.strictEqual(relativeImportPath('a/b/c.py', '....foo'), '../foo')
     })
 })

--- a/template/src/language-specs/python.test.ts
+++ b/template/src/language-specs/python.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { pythonSpec, relativeImportPath } from './python'
 import { nilFilterContext, nilResult } from './spec.test'
 

--- a/template/src/language-specs/python.ts
+++ b/template/src/language-specs/python.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+
 import { pythonStyleComment } from './comments'
 import { FilterContext, LanguageSpec, Result } from './spec'
 import { extractFromLines, filterResultsByImports, removeExtension } from './util'

--- a/template/src/language-specs/typescript.test.ts
+++ b/template/src/language-specs/typescript.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { nilFilterContext, nilResult } from './spec.test'
 import { typescriptSpec } from './typescript'
 

--- a/template/src/language-specs/typescript.ts
+++ b/template/src/language-specs/typescript.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+
 import { cStyleComment } from './comments'
 import { FilterContext, LanguageSpec, Result, LSIFSupport } from './spec'
 import { extractFromLines, filterResultsByImports, removeExtension } from './util'

--- a/template/src/language-specs/util.ts
+++ b/template/src/language-specs/util.ts
@@ -33,7 +33,7 @@ export function extractFromLines(fileContent: string, ...patterns: RegExp[]): st
  *
  * @param results A list of results to filter.
  * @param importPaths A list of import paths.
- * @param fn The filter function.
+ * @param func The filter function.
  */
 export function filterResultsByImports<T extends Result>(
     results: T[],
@@ -48,7 +48,7 @@ export function filterResultsByImports<T extends Result>(
  * function returns the original input unchanged.
  *
  * @param results A list of results to filter.
- * @param fn The filter function.
+ * @param func The filter function.
  */
 export function filterResults<T extends Result>(results: T[], func: (result: T) => boolean): T[] {
     const filteredResults = results.filter(result => func(result))

--- a/template/src/language-specs/util.ts
+++ b/template/src/language-specs/util.ts
@@ -1,4 +1,5 @@
 import { isDefined } from '../util/helpers'
+
 import { Result } from './spec'
 
 /**

--- a/template/src/lsif/definition-hover.test.ts
+++ b/template/src/lsif/definition-hover.test.ts
@@ -1,7 +1,10 @@
 import * as assert from 'assert'
+
 import * as sinon from 'sinon'
 import * as sourcegraph from 'sourcegraph'
+
 import { QueryGraphQLFn } from '../util/graphql'
+
 import { GenericLSIFResponse } from './api'
 import { definitionAndHoverForPosition, DefinitionAndHoverResponse } from './definition-hover'
 import { makeEnvelope, resource1, resource2, resource3, range1, range2, range3, document, position } from './util.test'

--- a/template/src/lsif/definition-hover.ts
+++ b/template/src/lsif/definition-hover.ts
@@ -99,7 +99,8 @@ export async function definitionAndHoverForPosition(
  * Convert a GraphQL definition and hover response into an object consisting of a list of Sourcegraph
  * locations and a markdown-formatted hover object.
  *
- * @param lsifObj The resolved LSIF object.
+ * @param textDocument The current document.
+ * @param lsifObject The resolved LSIF object.
  */
 export function definitionAndHoverResponseToLocations(
     textDocument: sourcegraph.TextDocument,

--- a/template/src/lsif/definition-hover.ts
+++ b/template/src/lsif/definition-hover.ts
@@ -1,9 +1,11 @@
 import * as sourcegraph from 'sourcegraph'
 import gql from 'tagged-template-noop'
-import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
-import { LocationConnectionNode, nodeToLocation } from './locations'
-import { GenericLSIFResponse, queryLSIF } from './api'
+
 import { DefinitionAndHover } from '../providers'
+import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
+
+import { GenericLSIFResponse, queryLSIF } from './api'
+import { LocationConnectionNode, nodeToLocation } from './locations'
 
 export type DefinitionAndHoverResponse = Partial<DefinitionResponse> & HoverResponse
 

--- a/template/src/lsif/highlights.test.ts
+++ b/template/src/lsif/highlights.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
-import { range1, range2, range3, range4, document } from './util.test'
+
 import { filterLocationsForDocumentHighlights } from './highlights'
+import { range1, range2, range3, range4, document } from './util.test'
 
 describe('filterLocationsForDocumentHighlights', () => {
     it('should filter out distinct paths', () => {

--- a/template/src/lsif/highlights.ts
+++ b/template/src/lsif/highlights.ts
@@ -1,4 +1,5 @@
 import * as sourcegraph from 'sourcegraph'
+
 import { isDefined } from '../util/helpers'
 
 export function filterLocationsForDocumentHighlights(

--- a/template/src/lsif/locations.test.ts
+++ b/template/src/lsif/locations.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert'
+
 import * as sourcegraph from 'sourcegraph'
+
 import { nodeToLocation } from './locations'
 
 describe('nodeToLocation', () => {

--- a/template/src/lsif/locations.ts
+++ b/template/src/lsif/locations.ts
@@ -1,4 +1,5 @@
 import * as sourcegraph from 'sourcegraph'
+
 import { parseGitURI } from '../util/uri'
 
 export interface LocationConnectionNode {

--- a/template/src/lsif/locations.ts
+++ b/template/src/lsif/locations.ts
@@ -14,7 +14,7 @@ export interface LocationConnectionNode {
 /**
  * Convert a GraphQL location connection node into a Sourcegraph location.
  *
- * @param doc The current document.
+ * @param textDocument The current document.
  * @param node A location connection node.
  */
 export function nodeToLocation(

--- a/template/src/lsif/providers.test.ts
+++ b/template/src/lsif/providers.test.ts
@@ -242,9 +242,9 @@ describe('graphql providers', () => {
                 [[location1], [location1, location2], [location1, location2, location3]]
             )
 
-            assert.equal(queryGraphQLFn.getCall(0).args[1]?.after, undefined)
-            assert.equal(queryGraphQLFn.getCall(1).args[1]?.after, 'page2')
-            assert.equal(queryGraphQLFn.getCall(2).args[1]?.after, 'page3')
+            assert.strictEqual(queryGraphQLFn.getCall(0).args[1]?.after, undefined)
+            assert.strictEqual(queryGraphQLFn.getCall(1).args[1]?.after, 'page2')
+            assert.strictEqual(queryGraphQLFn.getCall(2).args[1]?.after, 'page3')
         })
 
         it('should not page results indefinitely', async () => {
@@ -275,7 +275,7 @@ describe('graphql providers', () => {
                 values
             )
 
-            assert.equal(queryGraphQLFn.callCount, MAX_REFERENCE_PAGE_REQUESTS)
+            assert.strictEqual(queryGraphQLFn.callCount, MAX_REFERENCE_PAGE_REQUESTS)
         })
     })
 

--- a/template/src/lsif/providers.test.ts
+++ b/template/src/lsif/providers.test.ts
@@ -1,9 +1,13 @@
 import * as assert from 'assert'
+
 import * as sinon from 'sinon'
 import * as sourcegraph from 'sourcegraph'
+
 import { QueryGraphQLFn } from '../util/graphql'
-import { createGraphQLProviders as createProviders } from './providers'
+
 import { GenericLSIFResponse } from './api'
+import { DefinitionResponse, DefinitionAndHoverResponse } from './definition-hover'
+import { createGraphQLProviders as createProviders } from './providers'
 import { ReferencesResponse, MAX_REFERENCE_PAGE_REQUESTS } from './references'
 import {
     gatherValues,
@@ -21,7 +25,6 @@ import {
     document,
     position,
 } from './util.test'
-import { DefinitionResponse, DefinitionAndHoverResponse } from './definition-hover'
 
 describe('graphql providers', () => {
     describe('combined definition and hover provider', () => {

--- a/template/src/lsif/providers.ts
+++ b/template/src/lsif/providers.ts
@@ -1,13 +1,15 @@
 import * as sourcegraph from 'sourcegraph'
+
+import { Logger } from '../logging'
 import { noopProviders, CombinedProviders, DefinitionAndHover } from '../providers'
 import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
 import { asyncGeneratorFromPromise, cachePromiseProvider } from '../util/ix'
-import { Logger } from '../logging'
+import { raceWithDelayOffset } from '../util/promise'
+
+import { definitionAndHoverForPosition, hoverPayloadToHover } from './definition-hover'
+import { filterLocationsForDocumentHighlights } from './highlights'
 import { RangeWindowFactoryFn, makeRangeWindowFactory } from './ranges'
 import { referencesForPosition, referencePageForPosition } from './references'
-import { filterLocationsForDocumentHighlights } from './highlights'
-import { raceWithDelayOffset } from '../util/promise'
-import { definitionAndHoverForPosition, hoverPayloadToHover } from './definition-hover'
 
 /**
  * Creates providers powered by LSIF-based code intelligence. This particular

--- a/template/src/lsif/ranges.test.ts
+++ b/template/src/lsif/ranges.test.ts
@@ -43,9 +43,9 @@ describe('findOverlappingWindows', () => {
         const expected = [{ ...aggregate2, definitions: undefined, hover: undefined, references: undefined }]
 
         assert.deepEqual(await findOverlappingWindows(document, position, windows, queryGraphQLFn), expected)
-        assert.equal(windows.length, 3)
-        assert.equal(windows[1].startLine, 4)
-        assert.equal(windows[1].endLine, 6)
+        assert.strictEqual(windows.length, 3)
+        assert.strictEqual(windows[1].startLine, 4)
+        assert.strictEqual(windows[1].endLine, 6)
         assert.deepEqual(await windows[0].ranges, [aggregate1])
         assert.deepEqual(await windows[1].ranges, expected)
         assert.deepEqual(await windows[2].ranges, [aggregate3])
@@ -63,7 +63,7 @@ describe('findOverlappingWindows', () => {
 
         // Rejected promises (once no longer in-flight) do not stay in the cache
         await assert.rejects(findOverlappingWindows(document, position, windows, queryGraphQLFn1), new Error('oops'))
-        assert.equal(windows.length, 2)
+        assert.strictEqual(windows.length, 2)
 
         const queryGraphQLFn2 = sinon.spy<QueryGraphQLFn<GenericLSIFResponse<RangesResponse | null>>>(() =>
             makeEnvelope({ ranges: { nodes: [aggregate2] } })
@@ -72,9 +72,9 @@ describe('findOverlappingWindows', () => {
         const expected = [{ ...aggregate2, definitions: undefined, hover: undefined, references: undefined }]
 
         assert.deepEqual(await findOverlappingWindows(document, position, windows, queryGraphQLFn2), expected)
-        assert.equal(windows.length, 3)
-        assert.equal(windows[1].startLine, 4)
-        assert.equal(windows[1].endLine, 6)
+        assert.strictEqual(windows.length, 3)
+        assert.strictEqual(windows[1].startLine, 4)
+        assert.strictEqual(windows[1].endLine, 6)
         assert.deepEqual(await windows[0].ranges, [aggregate1])
         assert.deepEqual(await windows[1].ranges, expected)
         assert.deepEqual(await windows[2].ranges, [aggregate3])
@@ -110,7 +110,7 @@ describe('findOverlappingCodeIntelligenceRange', () => {
         const overlappingPositions = [new sourcegraph.Position(10, 5), new sourcegraph.Position(10, 6)]
 
         for (const position of overlappingPositions) {
-            assert.equal(findOverlappingCodeIntelligenceRange(position, [range]), range)
+            assert.strictEqual(findOverlappingCodeIntelligenceRange(position, [range]), range)
         }
 
         const disjointPositions = [
@@ -122,7 +122,7 @@ describe('findOverlappingCodeIntelligenceRange', () => {
         ]
 
         for (const position of disjointPositions) {
-            assert.equal(findOverlappingCodeIntelligenceRange(position, [range]), null)
+            assert.strictEqual(findOverlappingCodeIntelligenceRange(position, [range]), null)
         }
     })
 
@@ -138,7 +138,7 @@ describe('findOverlappingCodeIntelligenceRange', () => {
         ]
 
         for (const position of overlappingPositions) {
-            assert.equal(findOverlappingCodeIntelligenceRange(position, [range]), range)
+            assert.strictEqual(findOverlappingCodeIntelligenceRange(position, [range]), range)
         }
 
         const disjointPositions = [
@@ -149,7 +149,7 @@ describe('findOverlappingCodeIntelligenceRange', () => {
         ]
 
         for (const position of disjointPositions) {
-            assert.equal(findOverlappingCodeIntelligenceRange(position, [range]), null)
+            assert.strictEqual(findOverlappingCodeIntelligenceRange(position, [range]), null)
         }
     })
 
@@ -162,7 +162,7 @@ describe('findOverlappingCodeIntelligenceRange', () => {
         ]
 
         const position = new sourcegraph.Position(3, 5)
-        assert.equal(findOverlappingCodeIntelligenceRange(position, ranges), ranges[3])
+        assert.strictEqual(findOverlappingCodeIntelligenceRange(position, ranges), ranges[3])
     })
 })
 

--- a/template/src/lsif/ranges.test.ts
+++ b/template/src/lsif/ranges.test.ts
@@ -1,6 +1,11 @@
 import * as assert from 'assert'
+
 import * as sinon from 'sinon'
 import * as sourcegraph from 'sourcegraph'
+
+import { QueryGraphQLFn } from '../util/graphql'
+
+import { GenericLSIFResponse } from './api'
 import {
     calculateRangeWindow,
     rangesInRangeWindow,
@@ -9,8 +14,6 @@ import {
     findOverlappingCodeIntelligenceRange,
 } from './ranges'
 import { range1, makeEnvelope, range2, range3, document, makeResource, position } from './util.test'
-import { QueryGraphQLFn } from '../util/graphql'
-import { GenericLSIFResponse } from './api'
 
 describe('findOverlappingWindows', () => {
     const aggregate1 = { range: range1 }

--- a/template/src/lsif/ranges.ts
+++ b/template/src/lsif/ranges.ts
@@ -119,7 +119,7 @@ export async function makeRangeWindowFactory(
  * bounds calculations are efficient and early-out contains conditions are ensured
  * to be correct.
  *
- * @param doc The current document.
+ * @param textDocument The current document.
  * @param position The target position.
  * @param rangeWindows The set of windows known to the document.
  * @param queryGraphQL The function used to query the GraphQL API.
@@ -364,8 +364,8 @@ export interface CodeIntelligenceRangeConnectionNode {
 /**
  * Convert a GraphQL ranges response into a list of code intelligence ranges.
  *
- * @param doc The current document.
- * @param lsifObj The resolved LSIF object.
+ * @param textDocument The current document.
+ * @param lsifObject The resolved LSIF object.
  */
 export function rangesResponseToCodeIntelligenceRangeNodes(
     textDocument: sourcegraph.TextDocument,
@@ -377,7 +377,7 @@ export function rangesResponseToCodeIntelligenceRangeNodes(
 /**
  * Convert LSIF response node into a CodeIntelligenceRange.
  *
- * @param doc The current document.
+ * @param textDocument The current document.
  * @param node A code intelligence range connection node.
  */
 export function nodeToCodeIntelligenceRange(

--- a/template/src/lsif/ranges.ts
+++ b/template/src/lsif/ranges.ts
@@ -1,9 +1,11 @@
 import * as sourcegraph from 'sourcegraph'
 import gql from 'tagged-template-noop'
+
 import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
-import { LocationConnectionNode, nodeToLocation } from './locations'
-import { HoverPayload } from './definition-hover'
+
 import { GenericLSIFResponse, queryLSIF } from './api'
+import { HoverPayload } from './definition-hover'
+import { LocationConnectionNode, nodeToLocation } from './locations'
 
 /** The size of the bounds on each ranges request. */
 const RANGE_WINDOW_SIZE = 50

--- a/template/src/lsif/references.test.ts
+++ b/template/src/lsif/references.test.ts
@@ -94,9 +94,9 @@ describe('referencesForPosition', () => {
             [location1, location2, location3],
         ])
 
-        assert.equal(queryGraphQLFn.getCall(0).args[1]?.after, undefined)
-        assert.equal(queryGraphQLFn.getCall(1).args[1]?.after, 'page2')
-        assert.equal(queryGraphQLFn.getCall(2).args[1]?.after, 'page3')
+        assert.strictEqual(queryGraphQLFn.getCall(0).args[1]?.after, undefined)
+        assert.strictEqual(queryGraphQLFn.getCall(1).args[1]?.after, 'page2')
+        assert.strictEqual(queryGraphQLFn.getCall(2).args[1]?.after, 'page3')
     })
 
     it('should not page results indefinitely', async () => {
@@ -120,6 +120,6 @@ describe('referencesForPosition', () => {
 
         assert.deepEqual(await gatherValues(referencesForPosition(document, position, queryGraphQLFn)), values)
 
-        assert.equal(queryGraphQLFn.callCount, MAX_REFERENCE_PAGE_REQUESTS)
+        assert.strictEqual(queryGraphQLFn.callCount, MAX_REFERENCE_PAGE_REQUESTS)
     })
 })

--- a/template/src/lsif/references.test.ts
+++ b/template/src/lsif/references.test.ts
@@ -1,7 +1,10 @@
 import * as assert from 'assert'
+
 import * as sinon from 'sinon'
 import * as sourcegraph from 'sourcegraph'
+
 import { QueryGraphQLFn } from '../util/graphql'
+
 import { GenericLSIFResponse } from './api'
 import { ReferencesResponse, MAX_REFERENCE_PAGE_REQUESTS, referencesForPosition } from './references'
 import {

--- a/template/src/lsif/references.ts
+++ b/template/src/lsif/references.ts
@@ -1,9 +1,11 @@
 import * as sourcegraph from 'sourcegraph'
 import gql from 'tagged-template-noop'
+
 import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
 import { concat } from '../util/ix'
-import { nodeToLocation, LocationConnectionNode } from './locations'
+
 import { queryLSIF, GenericLSIFResponse } from './api'
+import { nodeToLocation, LocationConnectionNode } from './locations'
 
 /**
  * The maximum number of chained GraphQL requests to make for a single

--- a/template/src/lsif/references.ts
+++ b/template/src/lsif/references.ts
@@ -123,8 +123,8 @@ export async function referencePageForPosition(
 /**
  * Convert a GraphQL reference response into a set of Sourcegraph locations and end cursor.
  *
- * @param doc The current document.
- * @param lsifObj The resolved LSIF object.
+ * @param textDocument The current document.
+ * @param lsifObject The resolved LSIF object.
  */
 export function referenceResponseToLocations(
     textDocument: sourcegraph.TextDocument,

--- a/template/src/lsif/util.test.ts
+++ b/template/src/lsif/util.test.ts
@@ -1,5 +1,7 @@
 import * as sourcegraph from 'sourcegraph'
+
 import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
+
 import { GenericLSIFResponse } from './api'
 
 export const document = createStubTextDocument({

--- a/template/src/lsif/util.test.ts
+++ b/template/src/lsif/util.test.ts
@@ -10,7 +10,11 @@ export const document = createStubTextDocument({
     text: undefined,
 })
 
-export const makeResource = (name: string, oid: string, path: string) => ({
+export const makeResource = (
+    name: string,
+    oid: string,
+    path: string
+): { repository: { name: string }; commit: { oid: string }; path: string } => ({
     repository: { name },
     commit: { oid },
     path,

--- a/template/src/providers.test.ts
+++ b/template/src/providers.test.ts
@@ -9,10 +9,11 @@ import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
 import * as indicators from './indicators'
 import { LSIFSupport } from './language-specs/spec'
 import {
-    clearReferenceResultCache, createDefinitionProvider,
+    clearReferenceResultCache,
+    createDefinitionProvider,
     createDocumentHighlightProvider,
     createHoverProvider,
-    createReferencesProvider
+    createReferencesProvider,
 } from './providers'
 import { API } from './util/api'
 

--- a/template/src/providers.test.ts
+++ b/template/src/providers.test.ts
@@ -1,16 +1,18 @@
-import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
 import * as assert from 'assert'
+
 import { Observable } from 'rxjs'
 import * as sinon from 'sinon'
 import * as sourcegraph from 'sourcegraph'
+
+import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
+
 import * as indicators from './indicators'
 import { LSIFSupport } from './language-specs/spec'
 import {
-    createDefinitionProvider,
+    clearReferenceResultCache, createDefinitionProvider,
     createDocumentHighlightProvider,
     createHoverProvider,
-    createReferencesProvider,
-    clearReferenceResultCache,
+    createReferencesProvider
 } from './providers'
 import { API } from './util/api'
 

--- a/template/src/providers.ts
+++ b/template/src/providers.ts
@@ -391,6 +391,7 @@ function logLocationResults<T extends sourcegraph.Badged<sourcegraph.Location>, 
 /**
  * Creates a hover provider.
  *
+ * @param lsifSupport The level of LSIF support of the active language.
  * @param lsifProvider The LSIF-based definition and hover provider.
  * @param searchDefinitionProvider The search-based definition provider.
  * @param searchHoverProvider The search-based hover provider.

--- a/template/src/providers.ts
+++ b/template/src/providers.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
+
 import * as indicators from './indicators'
 import { LanguageSpec, LSIFSupport } from './language-specs/spec'
 import { Logger, NoopLogger } from './logging'

--- a/template/src/search/config.ts
+++ b/template/src/search/config.ts
@@ -1,4 +1,5 @@
 import * as sourcegraph from 'sourcegraph'
+
 import { SearchBasedCodeIntelligenceSettings } from './settings'
 
 /** Retrieves a config value by key. */

--- a/template/src/search/conversion.test.ts
+++ b/template/src/search/conversion.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert'
+
 import * as sourcegraph from 'sourcegraph'
+
 import { resultToLocation, searchResultToResults } from './conversion'
 
 describe('resultToLocation', () => {

--- a/template/src/search/conversion.ts
+++ b/template/src/search/conversion.ts
@@ -1,4 +1,5 @@
 import * as sourcegraph from 'sourcegraph'
+
 import { LineMatch, SearchResult, SearchSymbol } from '../util/api'
 import { isDefined } from '../util/helpers'
 

--- a/template/src/search/docstrings.test.ts
+++ b/template/src/search/docstrings.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert'
+
 import { cStyleComment, javaStyleComment, leadingHashPattern, pythonStyleComment } from '../language-specs/comments'
 import { CommentStyle } from '../language-specs/spec'
+
 import { findDocstring } from './docstrings'
 
 describe('docstrings', () => {

--- a/template/src/search/docstrings.ts
+++ b/template/src/search/docstrings.ts
@@ -101,7 +101,7 @@ function findDocstringOnDefinitionLine(line: string, { lineRegex, block }: Comme
  * before the definition in reverse order. This ordering will be undone `unmungeLines`.
  *
  * @param lines The lines of the text document.
- * @param docPlacement The placement of a docblock for the current language.
+ * @param textDocumentPlacement The placement of a docblock for the current language.
  * @param definitionLine The line on which the definition occurs.
  */
 function mungeLines(
@@ -118,7 +118,7 @@ function mungeLines(
  * If we reversed the order of the lines in `mungeLines`, undo that here.
  *
  * @param lines The lines of the text document.
- * @param docPlacement The placement of a docblock for the current language.
+ * @param textDocumentPlacement The placement of a docblock for the current language.
  */
 function unmungeLines(lines: string[], textDocumentPlacement: TextDocumentPlacement | undefined): string[] {
     return textDocumentPlacement === 'below the definition' ? lines : lines.reverse()

--- a/template/src/search/docstrings.ts
+++ b/template/src/search/docstrings.ts
@@ -1,4 +1,5 @@
 import { dropWhile, takeWhile } from 'lodash'
+
 import { BlockCommentStyle, CommentStyle, TextDocumentPlacement } from '../language-specs/spec'
 
 /**

--- a/template/src/search/markdown.test.ts
+++ b/template/src/search/markdown.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { wrapIndentationInCodeBlocks } from './markdown'
 
 describe('wrapping indentation in code blocks', () => {

--- a/template/src/search/providers.test.ts
+++ b/template/src/search/providers.test.ts
@@ -152,7 +152,7 @@ describe('search providers', () => {
                 [new sourcegraph.Location(new URL('git://repo1?rev1#/b.ts'), range1)],
             ])
 
-            assert.equal(searchStub.callCount, 1)
+            assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -175,7 +175,7 @@ describe('search providers', () => {
                 [[new sourcegraph.Location(new URL('git://repo1?rev1#/b.ts'), range1)]]
             )
 
-            assert.equal(searchStub.callCount, 1)
+            assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -199,7 +199,7 @@ describe('search providers', () => {
                 [new sourcegraph.Location(new URL('git://repo1?rev1#/b.ts'), range1)],
             ])
 
-            assert.equal(searchStub.callCount, 2)
+            assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -231,7 +231,7 @@ describe('search providers', () => {
                 ],
             ])
 
-            assert.equal(searchStub.callCount, 1)
+            assert.strictEqual(searchStub.callCount, 1)
         })
 
         it('should fallback to index-only queries', async () => {
@@ -249,7 +249,7 @@ describe('search providers', () => {
 
             assert.deepEqual(await values, [[new sourcegraph.Location(new URL('git://repo1?rev1#b.ts'), range1)]])
 
-            assert.equal(searchStub.callCount, 2)
+            assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -286,7 +286,7 @@ describe('search providers', () => {
                 [new sourcegraph.Location(new URL('git://repo1?rev1#/b.ts'), range1)],
             ])
 
-            assert.equal(searchStub.callCount, 3)
+            assert.strictEqual(searchStub.callCount, 3)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -325,7 +325,7 @@ describe('search providers', () => {
                 [new sourcegraph.Location(new URL('git://repo1?rev1#/b.ts'), range1)],
             ])
 
-            assert.equal(searchStub.callCount, 2)
+            assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -369,7 +369,7 @@ describe('search providers', () => {
                 ]
             )
 
-            assert.equal(searchStub.callCount, 2)
+            assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '\\bfoobar\\b',
                 'case:yes',
@@ -410,7 +410,7 @@ describe('search providers', () => {
                 ]
             )
 
-            assert.equal(searchStub.callCount, 2)
+            assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '\\bfoobar\\b',
                 'case:yes',
@@ -456,7 +456,7 @@ describe('search providers', () => {
                 ]
             )
 
-            assert.equal(searchStub.callCount, 4)
+            assert.strictEqual(searchStub.callCount, 4)
             assertQuery(searchStub.getCall(0).args[0], [
                 '\\bfoobar\\b',
                 'case:yes',
@@ -518,7 +518,7 @@ describe('search providers', () => {
                 ]
             )
 
-            assert.equal(searchStub.callCount, 4)
+            assert.strictEqual(searchStub.callCount, 4)
             assertQuery(searchStub.getCall(0).args[0], [
                 '\\bfoobar\\b',
                 'case:yes',
@@ -584,7 +584,7 @@ describe('search providers', () => {
                 },
             ])
 
-            assert.equal(searchStub.callCount, 1)
+            assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -593,7 +593,7 @@ describe('search providers', () => {
                 'type:symbol',
             ])
 
-            assert.equal(getFileContentStub.callCount, 2)
+            assert.strictEqual(getFileContentStub.callCount, 2)
             assert.deepEqual(getFileContentStub.secondCall.args, ['repo1', 'rev1', '/b.ts'])
         })
 
@@ -617,7 +617,7 @@ describe('search providers', () => {
                 },
             ])
 
-            assert.equal(searchStub.callCount, 2)
+            assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
                 'case:yes',
@@ -634,7 +634,7 @@ describe('search providers', () => {
                 'index:only',
             ])
 
-            assert.equal(getFileContentStub.callCount, 2)
+            assert.strictEqual(getFileContentStub.callCount, 2)
             assert.deepEqual(getFileContentStub.secondCall.args, ['repo1', 'rev1', '/b.ts'])
         })
     })

--- a/template/src/search/providers.test.ts
+++ b/template/src/search/providers.test.ts
@@ -1,14 +1,18 @@
-import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
 import * as assert from 'assert'
+
 import { afterEach, beforeEach } from 'mocha'
 import * as sinon from 'sinon'
 import * as sourcegraph from 'sourcegraph'
+
+import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
+
 import { cStyleComment } from '../language-specs/comments'
 import { LanguageSpec, Result } from '../language-specs/spec'
-import { API, SearchResult } from '../util/api'
-import { createProviders } from './providers'
 import { Providers, SourcegraphProviders } from '../providers'
+import { API, SearchResult } from '../util/api'
 import { observableFromAsyncIterator } from '../util/ix'
+
+import { createProviders } from './providers'
 
 const spec: LanguageSpec = {
     stylized: 'Lang',

--- a/template/src/search/providers.ts
+++ b/template/src/search/providers.ts
@@ -18,10 +18,7 @@ import { wrapIndentationInCodeBlocks } from './markdown'
 import { definitionQuery, referencesQuery } from './queries'
 import { findSearchToken } from './tokens'
 
-const documentHighlights = (
-    textDocument: sourcegraph.TextDocument,
-    position: sourcegraph.Position
-): Promise<sourcegraph.DocumentHighlight[] | null> => Promise.resolve(null)
+const documentHighlights = (): Promise<sourcegraph.DocumentHighlight[] | null> => Promise.resolve(null)
 
 /** The number of files whose content can be cached at once. */
 const FILE_CONTENT_CACHE_CAPACITY = 20

--- a/template/src/search/providers.ts
+++ b/template/src/search/providers.ts
@@ -1,20 +1,22 @@
 import { flatten, sortBy } from 'lodash'
-import { from, Observable, isObservable } from 'rxjs'
+import { from, isObservable, Observable } from 'rxjs'
 import { take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
+
 import { FilterDefinitions, LanguageSpec } from '../language-specs/spec'
 import { Providers } from '../providers'
 import { API } from '../util/api'
 import { asArray, isDefined } from '../util/helpers'
 import { asyncGeneratorFromPromise, cachePromiseProvider } from '../util/ix'
+import { raceWithDelayOffset } from '../util/promise'
 import { parseGitURI } from '../util/uri'
+
+import { getConfig } from './config'
 import { Result, resultToLocation, searchResultToResults } from './conversion'
 import { findDocstring } from './docstrings'
 import { wrapIndentationInCodeBlocks } from './markdown'
 import { definitionQuery, referencesQuery } from './queries'
 import { findSearchToken } from './tokens'
-import { getConfig } from './config'
-import { raceWithDelayOffset } from '../util/promise'
 
 const documentHighlights = (
     textDocument: sourcegraph.TextDocument,

--- a/template/src/search/providers.ts
+++ b/template/src/search/providers.ts
@@ -73,8 +73,8 @@ export function createProviders(
      * current hover position. Returns undefined if either piece of data could
      * not be determined.
      *
-     * @param doc The current text document.
-     * @param pos The current hover position.
+     * @param textDocument The current text document.
+     * @param position The current hover position.
      */
     const getContentAndToken = async (
         textDocument: sourcegraph.TextDocument,
@@ -102,8 +102,8 @@ export function createProviders(
     /**
      * Retrieve a definition for the current hover position.
      *
-     * @param doc The current text document.
-     * @param pos The current hover position.
+     * @param textDocument The current text document.
+     * @param position The current hover position.
      */
     const definition = async (
         textDocument: sourcegraph.TextDocument,
@@ -153,8 +153,8 @@ export function createProviders(
     /**
      * Retrieve references for the current hover position.
      *
-     * @param doc The current text document.
-     * @param pos The current hover position.
+     * @param textDocument The current text document.
+     * @param position The current hover position.
      */
     const references = async (
         textDocument: sourcegraph.TextDocument,
@@ -199,8 +199,8 @@ export function createProviders(
     /**
      * Retrieve hover text for the current hover position.
      *
-     * @param doc The current text document.
-     * @param pos The current hover position.
+     * @param textDocument The current text document.
+     * @param position The current hover position.
      */
     const hover = async (
         textDocument: sourcegraph.TextDocument,
@@ -481,7 +481,7 @@ async function search(api: API, queryTerms: string[]): Promise<Result[]> {
  * Report whether the given symbol is both private and does not belong to
  * the current text document.
  *
- * @param doc The current text document.
+ * @param textDocument The current text document.
  * @param path The path of the document.
  * @param result The search result.
  */

--- a/template/src/search/queries.test.ts
+++ b/template/src/search/queries.test.ts
@@ -1,6 +1,9 @@
-import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
 import * as assert from 'assert'
+
 import * as sourcegraph from 'sourcegraph'
+
+import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
+
 import { definitionQuery, referencesQuery } from './queries'
 
 describe('search requests', () => {

--- a/template/src/search/queries.ts
+++ b/template/src/search/queries.ts
@@ -1,5 +1,7 @@
 import { extname } from 'path'
+
 import * as sourcegraph from 'sourcegraph'
+
 import { parseGitURI } from '../util/uri'
 
 /**

--- a/template/src/search/tokens.test.ts
+++ b/template/src/search/tokens.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert'
+
 import { cStyleBlockComment, slashPattern } from '../language-specs/comments'
+
 import { findSearchToken } from './tokens'
 
 describe('findSearchToken', () => {

--- a/template/src/search/tokens.ts
+++ b/template/src/search/tokens.ts
@@ -1,4 +1,5 @@
 import { flatten } from 'lodash'
+
 import { BlockCommentStyle } from '../language-specs/spec'
 
 /**

--- a/template/src/tsconfig.json
+++ b/template/src/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-  },
-  "exclude": ["dist"],
-}

--- a/template/src/util/api.ts
+++ b/template/src/util/api.ts
@@ -137,7 +137,7 @@ export class API {
      * input rev is not known to the Sourcegraph instance.
      *
      * @param repoName The repository's name.
-     * @param rev The revision.
+     * @param revision The revision.
      */
     public async resolveRev(repoName: string, revision: string): Promise<string | undefined> {
         const query = gql`
@@ -314,7 +314,7 @@ export class API {
      * not known to the Sourcegraph instance.
      *
      * @param repo The repository in which the file exists.
-     * @param rev The revision in which the target version of the file exists.
+     * @param revision The revision in which the target version of the file exists.
      * @param path The path of the file.
      */
     public async getFileContent(repo: string, revision: string, path: string): Promise<string | undefined> {

--- a/template/src/util/helpers.ts
+++ b/template/src/util/helpers.ts
@@ -31,7 +31,7 @@ export function asArray<T>(value: T | T[] | null): T[] {
  * modified result in the same shape as the input.
  *
  * @param value The list of values, a single value, or null.
- * @param fn The map function.
+ * @param func The map function.
  */
 export function mapArrayish<T, R>(value: T | T[] | null, func: (value: T) => R): R | R[] | null {
     return Array.isArray(value) ? value.map(func) : value ? func(value) : null
@@ -62,7 +62,7 @@ export function notIn<T>(excludelist: T[]): (value: T) => boolean {
  * Catches any errors that occur during invocation and returns undefined instead of
  * rejecting the promise.
  *
- * @param p The promise.
+ * @param promise The promise.
  */
 export function safePromise<P, R>(promise: (argument: P) => Promise<R>): (argument: P) => Promise<R | undefined> {
     return async (argument: P): Promise<R | undefined> => {

--- a/template/src/util/ix.test.ts
+++ b/template/src/util/ix.test.ts
@@ -1,6 +1,9 @@
-import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
-import * as sourcegraph from 'sourcegraph'
 import * as assert from 'assert'
+
+import * as sourcegraph from 'sourcegraph'
+
+import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
+
 import {
     asyncGeneratorFromPromise,
     concat,

--- a/template/src/util/ix.ts
+++ b/template/src/util/ix.ts
@@ -83,7 +83,7 @@ export async function* concat<T>(source: AsyncIterable<T[] | null>): AsyncIterab
  * Converts a function returning a promise into an async generator yielding the
  * resolved value of that promise.
  *
- * @param fn The promise function.
+ * @param func The promise function.
  */
 export function asyncGeneratorFromPromise<P extends unknown[], R>(
     func: (...args: P) => Promise<R>

--- a/template/src/util/ix.ts
+++ b/template/src/util/ix.ts
@@ -1,5 +1,5 @@
-import * as sourcegraph from 'sourcegraph'
 import { Observable, Observer } from 'rxjs'
+import * as sourcegraph from 'sourcegraph'
 
 /**
  * An async generator that yields no values.

--- a/template/src/util/uri.test.ts
+++ b/template/src/util/uri.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { parseGitURI } from './uri'
 
 describe('parseGitURI', () => {

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -10,8 +10,6 @@
       },
     ],
   },
-  "include": [
-    "src/**/*.ts",
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": ["dist"],
 }

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -10,6 +10,8 @@
       },
     ],
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*.ts",
+  ],
   "exclude": ["dist"],
 }


### PR DESCRIPTION
I assumed that `yarn run a b c` and `yarn run a && yarn run b && yarn run c` were equivalent, but I think that the former just runs the task `a` with arguments `b` and `c`.