### PR TITLE
Restore JavaScript activation event for TypeScript extension

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -12,7 +12,7 @@ async function main(): Promise<void> {
     await Promise.all(specs.map(spec => generate(spec)))
 }
 
-async function generate({ languageID, stylized }: LanguageSpec): Promise<void> {
+async function generate({ languageID, stylized, additionalLanguages = [] }: LanguageSpec): Promise<void> {
     console.log(`Generating ${languageID} extension`)
 
     const langDirectory = `generated-${languageID}`
@@ -38,7 +38,10 @@ async function generate({ languageID, stylized }: LanguageSpec): Promise<void> {
                 name: languageID,
                 title: `${stylized} code intelligence`,
                 description: `Provides search-based code intelligence for ${stylized} using the Sourcegraph search API`,
-                activationEvents: [`onLanguage:${languageID}`],
+                activationEvents: [
+                    `onLanguage:${languageID}`,
+                    ...additionalLanguages?.map(language => `onLanguage:${language}`),
+                ],
                 icon: `data:image/png;base64,${(await fs.readFile(iconFilename)).toString('base64')}`,
             },
             null,

--- a/template/src/language-specs/spec.ts
+++ b/template/src/language-specs/spec.ts
@@ -11,6 +11,14 @@ export interface LanguageSpec {
     languageID: string
 
     /**
+     * Languages that the extension should be activated for in addition to
+     * its main language.
+     *
+     * @example ["javascript"] for the TypeScript extension.
+     */
+    additionalLanguages?: string[]
+
+    /**
      * The name of the generated extension.
      */
     stylized: string

--- a/template/src/language-specs/typescript.ts
+++ b/template/src/language-specs/typescript.ts
@@ -33,6 +33,7 @@ function candidates(sourcePath: string, importPath: string): string[] {
 
 export const typescriptSpec: LanguageSpec = {
     languageID: 'typescript',
+    additionalLanguages: ['javascript'],
     stylized: 'TypeScript',
     fileExts: ['ts', 'tsx', 'js', 'jsx'],
     commentStyles: [cStyleComment],


### PR DESCRIPTION
Fix sourcegraph/sourcegraph#24911.

The TypeScript extension stopped activating on JavaScript files after we got rid of the special case TypeScript extension (see hard-coded activation events [here](https://github.com/sourcegraph/code-intel-extensions/pull/664/files#diff-f3cd26c742476c747ce7a411b397cfd472c66a58340b1f9e792149f8be858c06L39-L42)).