### PR TITLE
Don't put \b in the query unless the token begins/ends with \w

### DIFF
--- a/template/src/search/queries.ts
+++ b/template/src/search/queries.ts
@@ -1,6 +1,6 @@
-import { escapeRegExp } from 'lodash'
 import { extname } from 'path'
 
+import { escapeRegExp } from 'lodash'
 import * as sourcegraph from 'sourcegraph'
 
 import { parseGitURI } from '../util/uri'
@@ -23,6 +23,7 @@ export function definitionQuery({
     fileExts: string[]
 }): string[] {
     return [`^${searchToken}$`, 'type:symbol', 'patternType:regexp', 'case:yes', fileExtensionTerm(doc, fileExts)]
+    // return [`${searchToken}`, 'type:symbol', 'patternType:regexp', 'case:yes', fileExtensionTerm(doc, fileExts)]
 }
 
 /**

--- a/template/src/search/queries.ts
+++ b/template/src/search/queries.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from 'lodash'
 import { extname } from 'path'
 
 import * as sourcegraph from 'sourcegraph'
@@ -41,7 +42,15 @@ export function referencesQuery({
     /** File extensions used by the current extension. */
     fileExts: string[]
 }): string[] {
-    return [`\\b${searchToken}\\b`, 'type:file', 'patternType:regexp', 'case:yes', fileExtensionTerm(doc, fileExts)]
+    let pattern = ''
+    if (/^\w/.test(searchToken)) {
+        pattern += '\\b'
+    }
+    pattern += escapeRegExp(searchToken)
+    if (/\w$/.test(searchToken)) {
+        pattern += '\\b'
+    }
+    return [pattern, 'type:file', 'patternType:regexp', 'case:yes', fileExtensionTerm(doc, fileExts)]
 }
 
 const excludelist = new Set(['thrift', 'proto', 'graphql'])


### PR DESCRIPTION
Bug report https://github.com/sourcegraph/sourcegraph/issues/25322

Previously, we'd search for `\bfoo!\b` in Ruby, which matches nothing because `!\b` seldom (if ever) matches anything.

This changes our queries so that we'll search for `\bfoo!` in Ruby.