### PR TITLE
Fix error when indexed search is disabled

### DIFF
--- a/template/src/util/promise.ts
+++ b/template/src/util/promise.ts
@@ -27,7 +27,7 @@ export async function raceWithDelayOffset<T>(
     }
 
     const fallback = makeFallback()
-    const raceResults = await Promise.race([primary, fallback])
+    const raceResults = await Promise.race([primary, fallback.catch(() => primary)])
     if (filter(raceResults)) {
         return raceResults
     }


### PR DESCRIPTION
Previously, whenever a Sourcegraph instance disabled indexed search via `"search.indexed.enabled": false` and search-based code intel did a `index:only` search, an error would get thrown and code intel would not return any results.

After this change, code intel will return the unindexed result if the indexed search errored out.

Asking in `#extensibility` if there's a way to detect if indexed search has been disabled https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1632530150197200

![CleanShot 2021-09-24 at 19 06 37@2x](https://user-images.githubusercontent.com/1387653/134752773-4c8c7255-dd32-47c4-8a65-15babfb3bb59.png)
