### PR TITLE
Fix provider cache

### DIFF
--- a/template/src/util/ix.ts
+++ b/template/src/util/ix.ts
@@ -113,7 +113,7 @@ export function cachePromiseProvider<P extends unknown[], R>(
     const cache: CacheEntry[] = []
 
     return (...args) => {
-        for (const [index, entry] of cache.entries()) {
+        for (const [index, entry] of Array.from(cache.entries())) {
             if (compareProviderArguments(entry.args, args)) {
                 if (index !== 0) {
                     cache.splice(index, 1)


### PR DESCRIPTION
Another `for ... of blah.entries()` bug cc @efritz 

This also reduces network chatter, see the [papercut](https://github.com/sourcegraph/sourcegraph/discussions/24905?sort=top#discussioncomment-1320499)