### PR TITLE
Simplify caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "dot-json": "^1.2.2",
+    "fast-json-stable-stringify": "^2.1.0",
     "js-base64": "^3.7.1",
     "json2ts": "^0.0.7",
     "lodash": "^4.17.21",

--- a/template/src/lsif/providers.ts
+++ b/template/src/lsif/providers.ts
@@ -54,7 +54,7 @@ export function createGraphQLProviders(
     getRangeFromWindow?: Promise<RangeWindowFactoryFn>
 ): CombinedProviders {
     return {
-        definitionAndHover: cache(definitionAndHover(queryGraphQL, getStencil, getRangeFromWindow)),
+        definitionAndHover: cache(definitionAndHover(queryGraphQL, getStencil, getRangeFromWindow), { max: 5 }),
         references: references(queryGraphQL, getStencil, getRangeFromWindow),
         documentHighlights: asyncGeneratorFromPromise(documentHighlights(queryGraphQL, getStencil, getRangeFromWindow)),
     }

--- a/template/src/lsif/providers.ts
+++ b/template/src/lsif/providers.ts
@@ -5,7 +5,7 @@ import { Logger } from '../logging'
 import { noopProviders, CombinedProviders, DefinitionAndHover } from '../providers'
 import { API } from '../util/api'
 import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
-import { asyncGeneratorFromPromise, cachePromiseProvider } from '../util/ix'
+import { asyncGeneratorFromPromise } from '../util/ix'
 import { raceWithDelayOffset } from '../util/promise'
 
 import { definitionAndHoverForPosition, hoverPayloadToHover } from './definition-hover'
@@ -13,6 +13,7 @@ import { filterLocationsForDocumentHighlights } from './highlights'
 import { RangeWindowFactoryFn, makeRangeWindowFactory } from './ranges'
 import { referencesForPosition, referencePageForPosition } from './references'
 import { makeStencilFn, StencilFn } from './stencil'
+import { cache } from './util'
 
 /**
  * Creates providers powered by LSIF-based code intelligence. This particular
@@ -53,7 +54,7 @@ export function createGraphQLProviders(
     getRangeFromWindow?: Promise<RangeWindowFactoryFn>
 ): CombinedProviders {
     return {
-        definitionAndHover: cachePromiseProvider(definitionAndHover(queryGraphQL, getStencil, getRangeFromWindow)),
+        definitionAndHover: cache(definitionAndHover(queryGraphQL, getStencil, getRangeFromWindow)),
         references: references(queryGraphQL, getStencil, getRangeFromWindow),
         documentHighlights: asyncGeneratorFromPromise(documentHighlights(queryGraphQL, getStencil, getRangeFromWindow)),
     }

--- a/template/src/lsif/stencil.ts
+++ b/template/src/lsif/stencil.ts
@@ -1,10 +1,10 @@
-import LRU from 'lru-cache'
 import sourcegraph from 'sourcegraph'
 import gql from 'tagged-template-noop'
 
 import { QueryGraphQLFn, queryGraphQL as sgQueryGraphQL } from '../util/graphql'
 
 import { GenericLSIFResponse, queryLSIF } from './api'
+import { cache } from './util'
 
 export const stencil = async (
     uri: string,
@@ -41,19 +41,6 @@ const stencilQuery = gql`
         }
     }
 `
-
-const cache = <K, V>(func: (k: K) => V, cacheOptions?: LRU.Options<K, V>): ((k: K) => V) => {
-    const lru = new LRU<K, V>(cacheOptions)
-    return key => {
-        if (lru.has(key)) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            return lru.get(key)!
-        }
-        const value = func(key)
-        lru.set(key, value)
-        return value
-    }
-}
 
 export type StencilFn = (uri: string) => Promise<sourcegraph.Range[] | undefined>
 

--- a/template/src/lsif/util.ts
+++ b/template/src/lsif/util.ts
@@ -1,0 +1,19 @@
+import stringify from 'fast-json-stable-stringify'
+import LRU from 'lru-cache'
+
+export const cache = <Arguments extends unknown[], V>(
+    func: (...args: Arguments) => V,
+    cacheOptions?: LRU.Options<string, V>
+): ((...args: Arguments) => V) => {
+    const lru = new LRU<string, V>(cacheOptions)
+    return (...args) => {
+        const key = stringify(args)
+        if (lru.has(key)) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return lru.get(key)!
+        }
+        const value = func(...args)
+        lru.set(key, value)
+        return value
+    }
+}

--- a/template/src/search/providers.ts
+++ b/template/src/search/providers.ts
@@ -268,7 +268,7 @@ export function createProviders(
     }
 
     return {
-        definition: asyncGeneratorFromPromise(cache(definition)),
+        definition: asyncGeneratorFromPromise(cache(definition, { max: 5 })),
         references: asyncGeneratorFromPromise(references),
         hover: asyncGeneratorFromPromise(hover),
         documentHighlights: asyncGeneratorFromPromise(documentHighlights),

--- a/template/src/search/providers.ts
+++ b/template/src/search/providers.ts
@@ -4,10 +4,11 @@ import { take } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 
 import { FilterDefinitions, LanguageSpec } from '../language-specs/spec'
+import { cache } from '../lsif/util'
 import { Providers } from '../providers'
 import { API } from '../util/api'
 import { asArray, isDefined } from '../util/helpers'
-import { asyncGeneratorFromPromise, cachePromiseProvider } from '../util/ix'
+import { asyncGeneratorFromPromise } from '../util/ix'
 import { raceWithDelayOffset } from '../util/promise'
 import { parseGitURI } from '../util/uri'
 
@@ -267,7 +268,7 @@ export function createProviders(
     }
 
     return {
-        definition: asyncGeneratorFromPromise(cachePromiseProvider(definition)),
+        definition: asyncGeneratorFromPromise(cache(definition)),
         references: asyncGeneratorFromPromise(references),
         hover: asyncGeneratorFromPromise(hover),
         documentHighlights: asyncGeneratorFromPromise(documentHighlights),

--- a/template/src/util/ix.test.ts
+++ b/template/src/util/ix.test.ts
@@ -1,10 +1,6 @@
 import * as assert from 'assert'
 
-import {
-    asyncGeneratorFromPromise,
-    concat,
-    observableFromAsyncIterator,
-} from './ix'
+import { asyncGeneratorFromPromise, concat, observableFromAsyncIterator } from './ix'
 
 describe('observableFromAsyncIterator', () => {
     it('converts iterator into an observable', async () => {

--- a/template/src/util/ix.test.ts
+++ b/template/src/util/ix.test.ts
@@ -8,8 +8,6 @@ import {
     asyncGeneratorFromPromise,
     concat,
     observableFromAsyncIterator,
-    cachePromiseProvider,
-    PROMISE_CACHE_CAPACITY,
 } from './ix'
 
 describe('observableFromAsyncIterator', () => {
@@ -82,83 +80,6 @@ describe('asyncGeneratorFromPromise', () => {
         const iterable = asyncGeneratorFromPromise(async (value: number) => Promise.resolve(value * 2))
 
         assert.deepStrictEqual(await gatherValues(iterable(24)), [48])
-    })
-})
-
-const textDocument1 = createStubTextDocument({
-    uri: 'https://sourcegraph.test/repo@rev/-/raw/foo.ts',
-    languageId: 'typescript',
-    text: undefined,
-})
-const textDocument2 = createStubTextDocument({
-    uri: 'https://sourcegraph.test/repo@rev/-/raw/bar.ts',
-    languageId: 'typescript',
-    text: undefined,
-})
-
-const textDocument3 = createStubTextDocument({
-    uri: 'https://sourcegraph.test/repo@rev/-/raw/baz.ts',
-    languageId: 'typescript',
-    text: undefined,
-})
-
-const position1 = new sourcegraph.Position(10, 1)
-const position2 = new sourcegraph.Position(10, 2)
-const position3 = new sourcegraph.Position(10, 3)
-
-describe('cachePromiseProvider', () => {
-    it('caches the result', async () => {
-        let calls = 0
-        let resolutions = 0
-
-        const cachedPromise = cachePromiseProvider(
-            (textDocument: sourcegraph.TextDocument, position: sourcegraph.Position) => {
-                calls++
-
-                return new Promise<number>(resolve => {
-                    resolutions++
-                    resolve(position.line + position.character * 2)
-                })
-            }
-        )
-
-        const promise = cachedPromise(textDocument1, position1)
-        assert.strictEqual(await promise, 12)
-        assert.strictEqual(await promise, 12)
-        assert.strictEqual(await cachedPromise(textDocument2, position2), 14)
-        assert.strictEqual(await cachedPromise(textDocument3, position3), 16)
-        assert.strictEqual(await cachedPromise(textDocument2, position2), 14)
-        assert.strictEqual(await cachedPromise(textDocument1, position1), 12)
-        assert.strictEqual(calls, 3)
-        assert.strictEqual(resolutions, 3)
-    })
-
-    it('is bounded', async () => {
-        let calls = 0
-
-        const cachedPromise = cachePromiseProvider(
-            (textDocument: sourcegraph.TextDocument, position: sourcegraph.Position) => {
-                calls++
-                return new Promise<number>(resolve => resolve(position.line + position.character * 2))
-            }
-        )
-
-        for (let index = 0; index < PROMISE_CACHE_CAPACITY * 2; index++) {
-            await cachedPromise(textDocument1, new sourcegraph.Position(index, 1))
-        }
-        assert.strictEqual(calls, PROMISE_CACHE_CAPACITY * 2)
-
-        // Ensure that the later half are still cached - no new calls
-        for (let index = 0; index < PROMISE_CACHE_CAPACITY; index++) {
-            await cachedPromise(textDocument1, new sourcegraph.Position(2 * PROMISE_CACHE_CAPACITY - index - 1, 1))
-        }
-        assert.strictEqual(calls, PROMISE_CACHE_CAPACITY * 2)
-
-        // Ensure that the first half is not cached - all new calls
-        for (let index = 0; index < PROMISE_CACHE_CAPACITY; index++) {
-            await cachedPromise(textDocument1, new sourcegraph.Position(index, 1))
-        }
-        assert.strictEqual(calls, PROMISE_CACHE_CAPACITY * 3)
     })
 })
 

--- a/template/src/util/ix.test.ts
+++ b/template/src/util/ix.test.ts
@@ -1,9 +1,5 @@
 import * as assert from 'assert'
 
-import * as sourcegraph from 'sourcegraph'
-
-import { createStubTextDocument } from '@sourcegraph/extension-api-stubs'
-
 import {
     asyncGeneratorFromPromise,
     concat,

--- a/template/src/util/ix.ts
+++ b/template/src/util/ix.ts
@@ -1,5 +1,4 @@
 import { Observable, Observer } from 'rxjs'
-import * as sourcegraph from 'sourcegraph'
 
 /**
  * An async generator that yields no values.
@@ -91,57 +90,4 @@ export function asyncGeneratorFromPromise<P extends unknown[], R>(
     return async function* (...args: P): AsyncGenerator<R, void, unknown> {
         yield await func(...args)
     }
-}
-
-/** The maximum number of promise results to cache. */
-export const PROMISE_CACHE_CAPACITY = 5
-
-/**
- * Memoizes a function that returns a promise. Internally, this maintains a simple
- * bounded LRU cache.
- *
- * @param func The promise function.
- */
-export function cachePromiseProvider<P extends unknown[], R>(
-    func: (...args: P) => Promise<R>,
-    cacheCapacity: number = PROMISE_CACHE_CAPACITY
-): (...args: P) => Promise<R> {
-    interface CacheEntry {
-        args: P
-        value: Promise<R>
-    }
-    const cache: CacheEntry[] = []
-
-    return (...args) => {
-        for (const [index, entry] of Array.from(cache.entries())) {
-            if (compareProviderArguments(entry.args, args)) {
-                if (index !== 0) {
-                    cache.splice(index, 1)
-                    cache.unshift(entry)
-                }
-                return entry.value
-            }
-        }
-
-        const value = func(...args)
-        cache.unshift({ args, value })
-        while (cache.length > cacheCapacity) {
-            cache.pop()
-        }
-        return value
-    }
-}
-
-/**
- * Compare the arguments of definition, reference, and hover providers. This
- * will only compare the document and position arguments and will ignore the
- * third parameter on the references provider.
- *
- * @param arguments1 The first set of arguments to compare.
- * @param arguments2 The second set of arguments to compare.
- */
-function compareProviderArguments<P extends unknown>(arguments1: P, arguments2: P): boolean {
-    const [textDocument1, position1] = arguments1 as [sourcegraph.TextDocument, sourcegraph.Position]
-    const [textDocument2, position2] = arguments2 as [sourcegraph.TextDocument, sourcegraph.Position]
-    return textDocument1.uri === textDocument2.uri && position1.isEqual(position2)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3575,7 +3575,7 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==


### PR DESCRIPTION
- Replaces `cachePromiseProvider` with `cache` (which uses the `lru-cache` npm package)
- Moves `cache` to a new `util.ts` file
- Stringifies the arguments to the `cache`d function using the `fast-json-stable-stringify` npm package