### PR TITLE
fix LANGID

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -46,7 +46,7 @@ async function generate({ languageID, stylized, additionalLanguages = [] }: Lang
             },
             null,
             2
-        )
+        ).replace(/LANGID\b/g, languageID)
     )
 
     // Update README.md placeholders with language name


### PR DESCRIPTION
`LANGID` was not getting instantiated in the template `package.json`, which prevented find-implementations from opening the panel.

Fixup #683 