### PR TITLE
Guard use of sub()

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -79,7 +79,7 @@
         "title": "Find implementations",
         "command": "open",
         "commandArguments": [
-          "${sub(get(context, 'panel.url'), 'panelID', 'implementations_LANGID')}"
+          "${get(context, 'implementations') && get(context, 'panel.url') && sub(get(context, 'panel.url'), 'panelID', 'implementations_LANGID') || 'noop'}"
         ],
         "actionItem": {
           "label": "Find implementations"


### PR DESCRIPTION
Calling `sub()` on older versions of Sourcegraph throws an error because `commandArguments` are evaluated eagerly (rather than lazily once the command is triggered):

![Screenshot from 2021-11-15 13-30-11](https://user-images.githubusercontent.com/1387653/141841289-b2350eec-a16d-4919-a4e6-c7cab76e33dd.png)
