### PR TITLE
Only show "Find implementations" for languages that support it

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -53,7 +53,7 @@
       "hover": [
         {
           "action": "findImplementations",
-          "when": "get(context, \"implementations\") && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)"
+          "when": "get(context, `implementations_${resource.language}`) && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)"
         }
       ]
     },
@@ -79,7 +79,7 @@
         "title": "Find implementations",
         "command": "open",
         "commandArguments": [
-          "${get(context, 'implementations') && get(context, 'panel.url') && sub(get(context, 'panel.url'), 'panelID', 'implementations_LANGID') || 'noop'}"
+          "${get(context, 'implementations_LANGID') && get(context, 'panel.url') && sub(get(context, 'panel.url'), 'panelID', 'implementations_LANGID') || 'noop'}"
         ],
         "actionItem": {
           "label": "Find implementations"

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -121,11 +121,16 @@ const activateCodeIntel = async (
     // TODO reenable the browser extension upon next release (Nov 22).
     // See https://github.com/sourcegraph/sourcegraph/issues/27239
     if (hasImplementationsFieldConst && sourcegraph.internal.clientApplication === 'sourcegraph') {
-        // Show the "Find implementations" button in the hover, as specified in package.json (look for
-        // "findImplementations").
-        sourcegraph.internal.updateContext({ implementations: true })
-
         if (languageSpec.textDocumentImplemenationSupport) {
+            // Show the "Find implementations" button in the hover, as specified in package.json (look for
+            // "findImplementations").
+            sourcegraph.internal.updateContext({
+                // For the hover
+                [`implementations_${languageSpec.languageID}`]: true,
+                // For the action that opens the panel
+                [`implementations_${languageID === 'all' ? 'LANGID' : languageSpec.languageID}`]: true,
+            })
+
             // Create an Implementations panel and register a locations provider.
             createImplementationPanel(context, selector, languageSpec, providers)
         }


### PR DESCRIPTION
Forgot to do hide the button for languages that we know don't support implementations in #683 