### PR TITLE
spike: Reduce network chattiness

### DIFF
--- a/template/src/lsif/api.ts
+++ b/template/src/lsif/api.ts
@@ -22,9 +22,14 @@ export async function queryLSIF<P extends { query: string; uri: string }, R>(
         ...rest
     }: P,
     queryGraphQL: QueryGraphQLFn<GenericLSIFResponse<R>>
-): Promise<R | null> {
+): Promise<R> {
     const { repo, commit, path } = parseGitURI(new URL(uri))
     const queryArguments = { repository: repo, commit, path, ...rest }
     const data = await queryGraphQL(query, queryArguments)
-    return data.repository?.commit?.blob?.lsif || null
+    const lsifData = data.repository?.commit?.blob?.lsif
+    if (!lsifData) {
+        throw new Error('No LSIF data')
+    }
+
+    return lsifData
 }


### PR DESCRIPTION
Ideas:

- [ ] When we catch _no LSIF data_ errors, we should mark that text document as not having LSIF data for a short amount of time and short-circuit the LSIF providers. Right now we'll hit the LSIF resolvers on all hover actions just to check that there are no uploads to service it. We can skip re-hitting this endpoint to get the same error, but re-check every 30s or so in case an upload comes in asynchronously.
- [ ] When we have LSIF data for a text document but do _not_ have a hover or definition for a particular position, we shouldn't fall back to search. This gives us hovers on things like _error_ in Go that are not linked to the stdlib which just jumps to a random line. Feels broken. (We should still mix precise and search-based _references_ though, and there are already explicit user flags to control this behavior).