### PR TITLE
search: Set explicit count:500 parameter in referencesQuery

### DIFF
--- a/template/src/search/providers.test.ts
+++ b/template/src/search/providers.test.ts
@@ -155,6 +155,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -178,6 +179,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo\\ with\\ spaces$@rev',
@@ -202,6 +204,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -209,6 +212,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -252,6 +256,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -259,6 +264,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',
@@ -289,6 +295,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 3)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -296,6 +303,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -303,6 +311,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.thirdCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -328,6 +337,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'fork:yes',
                 'patternType:regexp',
@@ -336,6 +346,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -372,6 +383,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -379,6 +391,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -413,6 +426,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo\\ with\\ spaces$@rev',
@@ -420,6 +434,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo\\ with\\ spaces$',
@@ -459,6 +474,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 4)
             assertQuery(searchStub.getCall(0).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -466,6 +482,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(1).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -473,6 +490,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(2).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',
@@ -481,6 +499,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(3).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -521,6 +540,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 4)
             assertQuery(searchStub.getCall(0).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'fork:yes',
                 'patternType:regexp',
@@ -529,6 +549,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(1).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -536,6 +557,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(2).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'fork:yes',
                 'index:only',
@@ -545,6 +567,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(3).args[0], [
                 '\\bfoobar\\b',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -587,6 +610,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -620,6 +644,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -627,6 +652,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
+                'count:500',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',

--- a/template/src/search/queries.test.ts
+++ b/template/src/search/queries.test.ts
@@ -23,6 +23,7 @@ describe('search requests', () => {
                     '^token$',
                     'type:symbol',
                     'patternType:regexp',
+                    'count:500',
                     'case:yes',
                     'file:\\.(cpp)$',
                 ],

--- a/template/src/search/queries.test.ts
+++ b/template/src/search/queries.test.ts
@@ -57,6 +57,7 @@ describe('search requests', () => {
                     '\\btoken\\b',
                     'type:file',
                     'patternType:regexp',
+                    'count:500',
                     'case:yes',
                     'file:\\.(cpp)$',
                 ],

--- a/template/src/search/queries.ts
+++ b/template/src/search/queries.ts
@@ -51,7 +51,7 @@ export function referencesQuery({
     if (/\w$/.test(searchToken)) {
         pattern += '\\b'
     }
-    return [pattern, 'type:file', 'patternType:regexp', 'case:yes', fileExtensionTerm(doc, fileExts)]
+    return [pattern, 'type:file', 'patternType:regexp', 'count:500', 'case:yes', fileExtensionTerm(doc, fileExts)]
 }
 
 const excludelist = new Set(['thrift', 'proto', 'graphql'])

--- a/template/src/search/queries.ts
+++ b/template/src/search/queries.ts
@@ -22,8 +22,14 @@ export function definitionQuery({
     /** File extensions used by the current extension. */
     fileExts: string[]
 }): string[] {
-    return [`^${searchToken}$`, 'type:symbol', 'patternType:regexp', 'case:yes', fileExtensionTerm(doc, fileExts)]
-    // return [`${searchToken}`, 'type:symbol', 'patternType:regexp', 'case:yes', fileExtensionTerm(doc, fileExts)]
+    return [
+        `^${searchToken}$`,
+        'type:symbol',
+        'patternType:regexp',
+        'count:500',
+        'case:yes',
+        fileExtensionTerm(doc, fileExts),
+    ]
 }
 
 /**


### PR DESCRIPTION
So far we relied on an implicit count being assumed. On the GraphQL API
that is 30. However, we had a bug that sometimes made us return more
than 30 results. When this bug was fixed in https://github.com/sourcegraph/sourcegraph/pull/29281,
the regression tests for find references failed, since we were now
cutting properly, and one of the expected references was then missing.

In general, @efritz commented that we assumed a `count:all`. That was
never the case, and doing so could be prohibitively expensive on
sourcegraph.com. So we instead ask for the display limit of 500 which is
already enforced.