### PR TITLE
Update to open alert on new window

### DIFF
--- a/template/src/indicators.ts
+++ b/template/src/indicators.ts
@@ -64,7 +64,7 @@ const makeAlert = ({
         iconKind: 'info',
         summary: {
             kind: sourcegraph.MarkupKind.Markdown,
-            value: `${message}<br /> [Learn more about precise code intelligence](${linkURL})`,
+            value: `${message}<br /> <a href="${linkURL})" target="_blank">Learn more about precise code intelligence</a>`,
         },
         ...legacyFields,
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30518.

## How to test
- Run `yarn run generate --languages=typescript && yarn --cwd generated-typescript run serve`
- Go to sourcegraph.com
- Remove `WebHoverOverlay.dismissedAlerts` from localStorage
- Add `"sourcegraph/typescript": false` to `user settings -> extensions`
- Open any [TypeScript file](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions/-/blob/template/src/indicators.ts?L64) and hover over a token
- Make sure "Learn more ..." open on a new tab
- Don't forget to remove `"sourcegraph/typescript": false`