### PR TITLE
Configure renovate to stop tagging code intel for reviews

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["github>sourcegraph/renovate-config"],
-  "reviewers": ["team:code-intel"]
+  "reviewers": []
 }


### PR DESCRIPTION
These notifications create a lot of noise with the GitHub Slack
integration.

This is the same as #756 but with the commit in the main repo instead of
in a fork, since CI testing doesn't run for PRs from forks.