### PR TITLE
Fix broken hyperlink on hover

### DIFF
--- a/template/src/indicators.ts
+++ b/template/src/indicators.ts
@@ -64,7 +64,7 @@ const makeAlert = ({
         iconKind: 'info',
         summary: {
             kind: sourcegraph.MarkupKind.Markdown,
-            value: `${message}<br /> <a href="${linkURL})" target="_blank">Learn more about precise code intelligence</a>`,
+            value: `${message}<br /> <a href="${linkURL}" target="_blank">Learn more about precise code intelligence</a>`,
         },
         ...legacyFields,
     }


### PR DESCRIPTION
;) there's an extra parenthesis at the end

<img width="1123" alt="CleanShot 2022-02-18 at 20 40 43@2x" src="https://user-images.githubusercontent.com/8373004/154786379-e50bdd64-a67a-4220-8315-d40de64b1cb3.png">
