### PR TITLE
search-based: Only load 50 defs instead of 500

### DIFF
--- a/template/src/search/providers.test.ts
+++ b/template/src/search/providers.test.ts
@@ -155,7 +155,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -179,7 +179,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo\\ with\\ spaces$@rev',
@@ -204,7 +204,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -212,7 +212,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -256,7 +256,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -264,7 +264,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',
@@ -295,7 +295,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 3)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -303,7 +303,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -311,7 +311,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.thirdCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -337,7 +337,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'fork:yes',
                 'patternType:regexp',
@@ -346,7 +346,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -610,7 +610,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -644,7 +644,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -652,7 +652,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:500',
+                'count:50',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',

--- a/template/src/search/queries.test.ts
+++ b/template/src/search/queries.test.ts
@@ -23,7 +23,7 @@ describe('search requests', () => {
                     '^token$',
                     'type:symbol',
                     'patternType:regexp',
-                    'count:500',
+                    'count:50',
                     'case:yes',
                     'file:\\.(cpp)$',
                 ],

--- a/template/src/search/queries.ts
+++ b/template/src/search/queries.ts
@@ -26,7 +26,7 @@ export function definitionQuery({
         `^${searchToken}$`,
         'type:symbol',
         'patternType:regexp',
-        'count:500',
+        'count:50',
         'case:yes',
         fileExtensionTerm(doc, fileExts),
     ]


### PR DESCRIPTION
Usually there is only 1 definition, or maybe a few. A limit of 50 is plenty. This will make symbols requests faster.