### PR TITLE
Add request for non-local variable definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate": "yarn -s && yarn run ts-node -P tsconfig.json ./scripts/generate.ts",
     "publish": "yarn run ts-node -P tsconfig.json ./scripts/publish.ts",
     "config-types": "./node_modules/.bin/dot-json template/package.json contributes.configuration | ./node_modules/.bin/json2ts --unreachableDefinitions --style.singleQuote --no-style.semi -o ./template/src/search/settings.ts && yarn prettier",
-    "update-graphql-schema": "curl -s https://raw.githubusercontent.com/sourcegraph/sourcegraph/073276b06e8b98bce2a1102802d557c61474a16b/cmd/frontend/graphqlbackend/schema.graphql > ./schema/schema.graphql && curl -s https://raw.githubusercontent.com/sourcegraph/sourcegraph/073276b06e8b98bce2a1102802d557c61474a16b/cmd/frontend/graphqlbackend/codeintel.graphql >> ./schema/schema.graphql",
+    "update-graphql-schema": "curl -s https://raw.githubusercontent.com/sourcegraph/sourcegraph/293d3e00d379761fb82e8c7744d4d6f3b6bb65f4/cmd/frontend/graphqlbackend/schema.graphql > ./schema/schema.graphql && curl -s https://raw.githubusercontent.com/sourcegraph/sourcegraph/293d3e00d379761fb82e8c7744d4d6f3b6bb65f4/cmd/frontend/graphqlbackend/codeintel.graphql >> ./schema/schema.graphql",
     "validate-graphql": "yarn run tsgql validate -p ./template/tsconfig.json"
   },
   "dependencies": {

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -2280,6 +2280,7 @@ enum ExternalServiceKind {
     AWSCODECOMMIT
     BITBUCKETCLOUD
     BITBUCKETSERVER
+    GERRIT
     GITHUB
     GITLAB
     GITOLITE
@@ -2290,6 +2291,7 @@ enum ExternalServiceKind {
     PAGURE
     PERFORCE
     PHABRICATOR
+    PYTHONPACKAGES
 }
 
 """
@@ -3768,6 +3770,15 @@ type GitCommit implements Node {
     """
     externalURLs: [ExternalLink!]!
     """
+    The Git tree or blob in this commit at the given path.
+    """
+    path(
+        """
+        The path of the tree or blob.
+        """
+        path: String = ""
+    ): GitTreeOrBlob
+    """
     The Git tree in this commit at the given path.
     """
     tree(
@@ -3847,6 +3858,11 @@ type GitCommit implements Node {
         includePatterns: [String!]
     ): SymbolConnection!
 }
+
+"""
+Either a git tree or blob.
+"""
+union GitTreeOrBlob = GitTree | GitBlob
 
 """
 A set of Git behind/ahead counts for one commit relative to another.
@@ -6805,6 +6821,11 @@ extend type Mutation {
     Deletes an LSIF index.
     """
     deleteLSIFIndex(id: ID!): EmptyResponse
+
+    """
+    Request support for a particular language.
+    """
+    requestLanguageSupport(language: String!): EmptyResponse
 }
 
 extend type Query {
@@ -6971,6 +6992,11 @@ extend type Query {
         """
         repos: [String!]
     ): DocumentationSearchResults!
+
+    """
+    Return the languages that this user has requested support for.
+    """
+    requestedLanguageSupport: [String!]!
 }
 
 """
@@ -7226,6 +7252,11 @@ extend type Repository {
     ): LSIFIndexConnection!
 
     """
+    Provides a summary of the most reecent upload and index status.
+    """
+    codeIntelSummary: CodeIntelRepositorySummary!
+
+    """
     The set of git objects that match the given git object type and glob pattern.
     This resolver is used by the UI to preview what names match a code intelligence
     policy in a given repository.
@@ -7295,6 +7326,132 @@ extend type GitBlob {
     Experimental: This API is likely to change in the future.
     """
     localCodeIntel: JSONValue
+
+    """
+    A wrapper around syntactic hover and definition query methods.
+
+    Experimental: This API is likely to change in the future.
+    """
+    symbolInfo(line: Int!, character: Int!): SymbolInfo
+}
+
+"""
+SymbolInfo contains hover and definition methods. It's returned by GitBlob.symbolInfo(line, character).
+"""
+type SymbolInfo {
+    """
+    The definition of the symbol.
+    """
+    definition: SymbolLocation
+
+    """
+    The hover for the symbol.
+    """
+    hover: String
+}
+
+"""
+SymbolLocation is a single-line range within a repository. It's returned by SymbolInfo.definition.
+"""
+type SymbolLocation {
+    """
+    The repo.
+    """
+    repo: String!
+
+    """
+    The commit.
+    """
+    commit: String!
+
+    """
+    The path.
+    """
+    path: String!
+
+    """
+    The line.
+    """
+    line: Int!
+
+    """
+    The character.
+    """
+    character: Int!
+
+    """
+    The length.
+    """
+    length: Int!
+}
+
+"""
+A summary of the most reecent upload and index status.
+"""
+type CodeIntelRepositorySummary {
+    """
+    A list of recent uploads for a specific repository. This list contains processing,
+    recently queued, and the most recently processed uploads for each distinct indexer
+    and root.
+    """
+    recentUploads: [LSIFUploadsWithRepositoryNamespace!]!
+
+    """
+    A list of recent indexes for a specific repository. This list contains processing,
+    recently queued, and the most recently processed indexes for each distinct indexer
+    and root.
+    """
+    recentIndexes: [LSIFIndexesWithRepositoryNamespace!]!
+
+    """
+    The last time uploads of this repository were checked against data retention policies.
+    """
+    lastUploadRetentionScan: DateTime
+
+    """
+    The last time this repository was considered for auto-indexing job scheduling.
+    """
+    lastIndexScan: DateTime
+}
+
+"""
+A group of uploads that share the same root and indexer values.
+"""
+type LSIFUploadsWithRepositoryNamespace {
+    """
+    The root of all uploads in the associated connection.
+    """
+    root: String!
+
+    """
+    The indexer used to produce the each upload in the associated connection.
+    """
+    indexer: CodeIntelIndexer!
+
+    """
+    A list of uploads.
+    """
+    uploads: [LSIFUpload!]!
+}
+
+"""
+A group of indexes that share the same root and indexer values.
+"""
+type LSIFIndexesWithRepositoryNamespace {
+    """
+    The root of all indexes in the associated connection.
+    """
+    root: String!
+
+    """
+    The configured indexer of each index in the associated connection.
+    """
+    indexer: CodeIntelIndexer!
+
+    """
+    A list of indexes.
+    """
+    indexes: [LSIFIndex!]!
 }
 
 """
@@ -7868,6 +8025,11 @@ type LSIFUpload implements Node {
     inputIndexer: String!
 
     """
+    The indexer used to produce this index.
+    """
+    indexer: CodeIntelIndexer
+
+    """
     The upload's current state.
     """
     state: LSIFUploadState!
@@ -8012,6 +8174,11 @@ type LSIFIndex implements Node {
     The name of the target indexer Docker image (e.g., sourcegraph/lsif-go@sha256:...).
     """
     inputIndexer: String!
+
+    """
+    The indexer used to produce the index artifact.
+    """
+    indexer: CodeIntelIndexer
 
     """
     The index's current state.
@@ -8243,12 +8410,12 @@ type CodeIntelSupport {
     """
     Search-based code-intel support overview.
     """
-    searchBasedSupport: SearchBasedCodeIntelSupport!
+    searchBasedSupport: SearchBasedCodeIntelSupport
 
     """
     Precise code-intel support overview.
     """
-    preciseSupport: PreciseCodeIntelSupport!
+    preciseSupport: PreciseCodeIntelSupport
 }
 
 """
@@ -8314,7 +8481,7 @@ type SearchBasedCodeIntelSupport {
     The infered language the underlying tool infered when building an index for
     search-based code-intel.
     """
-    language: String
+    language: String!
 }
 
 """

--- a/template/src/search/providers.test.ts
+++ b/template/src/search/providers.test.ts
@@ -141,8 +141,11 @@ describe('search providers', () => {
         const stubHasLocalCodeIntelField = sinon.stub(api, 'hasLocalCodeIntelField')
         stubHasLocalCodeIntelField.callsFake(() => Promise.resolve(true))
 
-        const stubFindSymbol = sinon.stub(api, 'findSymbol')
+        const stubFindSymbol = sinon.stub(api, 'findLocalSymbol')
         stubFindSymbol.callsFake(() => Promise.resolve(undefined))
+
+        const stubFetchSymbolInfo = sinon.stub(api, 'fetchSymbolInfo')
+        stubFetchSymbolInfo.callsFake(() => Promise.resolve(undefined))
 
         return api
     }


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/35031

Depends on https://github.com/sourcegraph/sourcegraph/pull/35082

This requests a non-local variable definition if a local one could not be found.

**Reviewers: ignore the GraphQL changes - they're synced from sourcegraph/sourcegraph**