### PR TITLE
Add setting `basicCodeIntel.globalSearchesEnabled`

### DIFF
--- a/.buildkite/base-pipeline.yml
+++ b/.buildkite/base-pipeline.yml
@@ -8,8 +8,6 @@ steps:
     label: ':lipstick: :eslint:'
   - command: ./.buildkite/test.sh
     label: ':jest: :codecov:'
-  - command: echo "Update the Sourcegraph.com global settings to disable global searches first"; false
-    label: 'fail'
 
   # This runs the Checkov Terraform Code scanner
   # https://www.checkov.io/

--- a/.buildkite/base-pipeline.yml
+++ b/.buildkite/base-pipeline.yml
@@ -8,6 +8,8 @@ steps:
     label: ':lipstick: :eslint:'
   - command: ./.buildkite/test.sh
     label: ':jest: :codecov:'
+  - command: echo "Update the Sourcegraph.com global settings to disable global searches first"; false
+    label: 'fail'
 
   # This runs the Checkov Terraform Code scanner
   # https://www.checkov.io/

--- a/template/README.md
+++ b/template/README.md
@@ -60,6 +60,14 @@ For organizations that organize code in a monorepo, it may never be useful to pe
   "basicCodeIntel.indexOnly": true
 ```
 
+### Many repositories
+
+On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Global searches are enabled by default, but can disabled by adding the following to your Sourcegraph global settings:
+
+```json
+  "basicCodeIntel.globalSearchesEnabled": false
+```
+
 ## LSIF
 
 To enable [LSIF support](https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence), add these to your Sourcegraph global settings:

--- a/template/README.md
+++ b/template/README.md
@@ -62,7 +62,7 @@ For organizations that organize code in a monorepo, it may never be useful to pe
 
 ### Many repositories
 
-On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Global searches are enabled by default, but can disabled by adding the following to your Sourcegraph global settings:
+On instances with many repositories, global searches over all repositories can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Global searches are enabled by default, but can disabled by adding the following to your Sourcegraph global settings:
 
 ```json
   "basicCodeIntel.globalSearchesEnabled": false

--- a/template/package.json
+++ b/template/package.json
@@ -117,6 +117,10 @@
           "description": "Whether to include archived repositories in search results.",
           "type": "boolean"
         },
+        "basicCodeIntel.globalSearchesEnabled": {
+          "description": "Whether to search through all repositories. On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Defaults to true.",
+          "type": "boolean"
+        },
         "basicCodeIntel.indexOnly": {
           "description": "Whether to use only indexed requests to the search API.",
           "type": "boolean"

--- a/template/package.json
+++ b/template/package.json
@@ -118,7 +118,7 @@
           "type": "boolean"
         },
         "basicCodeIntel.globalSearchesEnabled": {
-          "description": "Whether to search through all repositories. On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Defaults to true.",
+          "description": "Whether to run global searches over all repositories. On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Defaults to true.",
           "type": "boolean"
         },
         "basicCodeIntel.indexOnly": {

--- a/template/src/search/config.ts
+++ b/template/src/search/config.ts
@@ -3,11 +3,13 @@ import * as sourcegraph from 'sourcegraph'
 import { SearchBasedCodeIntelligenceSettings } from './settings'
 
 /** Retrieves a config value by key. */
-export function getConfig<
-    K extends keyof SearchBasedCodeIntelligenceSettings,
-    T extends SearchBasedCodeIntelligenceSettings[K]
->(key: K, defaultValue: T): T {
-    return (
-        (sourcegraph.configuration.get<SearchBasedCodeIntelligenceSettings>().get(key) as T | undefined) || defaultValue
-    )
+export function getConfig<K extends keyof SearchBasedCodeIntelligenceSettings>(
+    key: K,
+    defaultValue: NonNullable<SearchBasedCodeIntelligenceSettings[K]>
+): NonNullable<SearchBasedCodeIntelligenceSettings[K]> {
+    const value = sourcegraph.configuration.get<SearchBasedCodeIntelligenceSettings>().get(key)
+    if (value === undefined) {
+        return defaultValue
+    }
+    return value as NonNullable<SearchBasedCodeIntelligenceSettings[K]>
 }

--- a/template/src/search/config.ts
+++ b/template/src/search/config.ts
@@ -3,7 +3,7 @@ import * as sourcegraph from 'sourcegraph'
 import { SearchBasedCodeIntelligenceSettings } from './settings'
 
 /** Retrieves a config value by key. */
-export function getConfig<T>(key: string, defaultValue: T): T {
+export function getConfig<K extends keyof SearchBasedCodeIntelligenceSettings, T extends SearchBasedCodeIntelligenceSettings[K]>(key: K, defaultValue: T): T {
     return (
         (sourcegraph.configuration.get<SearchBasedCodeIntelligenceSettings>().get(key) as T | undefined) || defaultValue
     )

--- a/template/src/search/config.ts
+++ b/template/src/search/config.ts
@@ -3,7 +3,10 @@ import * as sourcegraph from 'sourcegraph'
 import { SearchBasedCodeIntelligenceSettings } from './settings'
 
 /** Retrieves a config value by key. */
-export function getConfig<K extends keyof SearchBasedCodeIntelligenceSettings, T extends SearchBasedCodeIntelligenceSettings[K]>(key: K, defaultValue: T): T {
+export function getConfig<
+    K extends keyof SearchBasedCodeIntelligenceSettings,
+    T extends SearchBasedCodeIntelligenceSettings[K]
+>(key: K, defaultValue: T): T {
     return (
         (sourcegraph.configuration.get<SearchBasedCodeIntelligenceSettings>().get(key) as T | undefined) || defaultValue
     )

--- a/template/src/search/providers.ts
+++ b/template/src/search/providers.ts
@@ -193,7 +193,9 @@ export function createProviders(
         const sameRepoReferences = doSearch(false)
 
         // Perform an indexed search over all _other_ repositories.
-        const remoteRepoReferences = getConfig('basicCodeIntel.globalSearchesEnabled', true) ? Promise.resolve([]) : doSearch(true)
+        const remoteRepoReferences = getConfig('basicCodeIntel.globalSearchesEnabled', true)
+            ? Promise.resolve([])
+            : doSearch(true)
 
         // Resolve then merge all references and sort them by proximity
         // to the current text document path.

--- a/template/src/search/providers.ts
+++ b/template/src/search/providers.ts
@@ -149,7 +149,7 @@ export function createProviders(
 
         // Fallback to definitions found in any other repository. This performs
         // an indexed search over all repositories.
-        return getConfig('basicCodeIntel.globalSearchesEnabled', true) ? Promise.resolve([]) : doSearch(true)
+        return !getConfig('basicCodeIntel.globalSearchesEnabled', true) ? Promise.resolve([]) : doSearch(true)
     }
 
     /**
@@ -193,7 +193,7 @@ export function createProviders(
         const sameRepoReferences = doSearch(false)
 
         // Perform an indexed search over all _other_ repositories.
-        const remoteRepoReferences = getConfig('basicCodeIntel.globalSearchesEnabled', true)
+        const remoteRepoReferences = !getConfig('basicCodeIntel.globalSearchesEnabled', true)
             ? Promise.resolve([])
             : doSearch(true)
 

--- a/template/src/search/settings.ts
+++ b/template/src/search/settings.ts
@@ -31,7 +31,7 @@ export interface SearchBasedCodeIntelligenceSettings {
      */
     'basicCodeIntel.includeArchives'?: boolean
     /**
-     * Whether to search through all repositories.
+     * Whether to run global searches over all repositories.
      */
     'basicCodeIntel.globalSearchesEnabled'?: boolean
     /**

--- a/template/src/search/settings.ts
+++ b/template/src/search/settings.ts
@@ -45,5 +45,5 @@ export interface SearchBasedCodeIntelligenceSettings {
     /**
      * Whether to request the `fileLocal` field in GraphQL. It's unavailable in older versions of Sourcegraph. Defaults to false.
      */
-    'fileLocal'?: boolean
+    fileLocal?: boolean
 }

--- a/template/src/search/settings.ts
+++ b/template/src/search/settings.ts
@@ -31,6 +31,10 @@ export interface SearchBasedCodeIntelligenceSettings {
      */
     'basicCodeIntel.includeArchives'?: boolean
     /**
+     * Whether to search through all repositories.
+     */
+    'basicCodeIntel.globalSearchesEnabled'?: boolean
+    /**
      * Whether to use only indexed requests to the search API.
      */
     'basicCodeIntel.indexOnly'?: boolean
@@ -38,5 +42,8 @@ export interface SearchBasedCodeIntelligenceSettings {
      * The timeout (in milliseconds) for un-indexed search requests.
      */
     'basicCodeIntel.unindexedSearchTimeout'?: number
-    [k: string]: unknown
+    /**
+     * Whether to request the `fileLocal` field in GraphQL. It's unavailable in older versions of Sourcegraph. Defaults to false.
+     */
+    'fileLocal'?: boolean
 }


### PR DESCRIPTION
On instances with many repositories, global searches over all repositories can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Global searches are enabled by default, but can disabled by adding the following to your Sourcegraph global settings:

```json
  "basicCodeIntel.globalSearchesEnabled": false
```