### PR TITLE
remove codeIntel.lsif bool flag use

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -67,11 +67,3 @@ On instances with many repositories, global searches over all repositories can l
 ```json
   "basicCodeIntel.globalSearchesEnabled": false
 ```
-
-## LSIF
-
-To enable [LSIF support](https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence), add these to your Sourcegraph global settings:
-
-```json
-  "codeIntel.lsif": true
-```

--- a/template/package.json
+++ b/template/package.json
@@ -89,10 +89,6 @@
     "configuration": {
       "title": "Search-based code intelligence settings",
       "properties": {
-        "codeIntel.lsif": {
-          "description": "Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.",
-          "type": "boolean"
-        },
         "codeIntel.disableSearchBased": {
           "description": "Never fall back to search-based code intelligence.",
           "type": "boolean"

--- a/template/src/lsif/providers.ts
+++ b/template/src/lsif/providers.ts
@@ -2,7 +2,7 @@ import { once } from 'lodash'
 import * as sourcegraph from 'sourcegraph'
 
 import { Logger } from '../logging'
-import { noopProviders, CombinedProviders, DefinitionAndHover } from '../providers'
+import { CombinedProviders, DefinitionAndHover } from '../providers'
 import { cache } from '../util'
 import { API } from '../util/api'
 import { queryGraphQL as sgQueryGraphQL, QueryGraphQLFn } from '../util/graphql'
@@ -23,12 +23,6 @@ import { makeStencilFn, StencilFn } from './stencil'
  * @param logger The logger instance.
  */
 export function createProviders(hasImplementationsField: boolean, logger: Logger): CombinedProviders {
-    const enabled = sourcegraph.configuration.get().get('codeIntel.lsif') ?? true
-    if (!enabled) {
-        logger.log('LSIF is not enabled in global settings')
-        return noopProviders
-    }
-
     const providers = createGraphQLProviders(
         sgQueryGraphQL,
         makeStencilFn(

--- a/template/src/search/settings.ts
+++ b/template/src/search/settings.ts
@@ -7,10 +7,6 @@
 
 export interface SearchBasedCodeIntelligenceSettings {
     /**
-     * Whether to use pre-computed LSIF data for code intelligence (such as hovers, definitions, and references). See https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence.
-     */
-    'codeIntel.lsif'?: boolean
-    /**
      * Whether to enable trace logging on the extension.
      */
     'codeIntel.traceExtension'?: boolean


### PR DESCRIPTION
A long-awaited follow up on https://github.com/sourcegraph/sourcegraph/pull/17292, this removes references to the undocumented `codeIntel.lsif` flag that defaults to true today.