### PR TITLE
Check if panel view is supported by Sourcegraph instance

### DIFF
--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -23,7 +23,7 @@ const DUMMY_CTX = {
 const hasImplementationsField = once(() => new API().hasImplementationsField())
 
 /**
- * Create the panel for implementations.
+ * Create the panel for implementations (if supported by the Sourcegraph instance).
  *
  * Makes sure to only create the panel once per session.
  */
@@ -32,6 +32,11 @@ const createImplementationPanel = (
     selector: sourcegraph.DocumentSelector,
     providers: SourcegraphProviders
 ): void => {
+    // `createPanelView` was removed in https://github.com/sourcegraph/sourcegraph/pull/50451
+    if (!sourcegraph.app.createPanelView) {
+        return
+    }
+
     const implementationsPanelID = 'implementations_LANGID'
     const implementationsPanel = sourcegraph.app.createPanelView(implementationsPanelID)
 


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/50451 removed panel views.
This PR removes its usage in the code-intel extensions.

##### Context
Sourcegraph browser extension is shipped with [code-intel extension bundles](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@9bdc1f6f0d71e9f94d93e562830897df93c407ce/-/blob/client/shared/src/extensions/buildCodeIntelExtensions.js). The current browser extension version is shipped with code-intel extensions bundles [v3.41.1](https://github.com/sourcegraph/sourcegraph-extensions-bundles/releases/tag/v3.41.1) (defined in [client/browser/sourcegraph-extension-bundles-revision.txt](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@9bdc1f6/-/blob/client/browser/sourcegraph-extension-bundles-revision.txt)) built on Jul 12, 2022 from this repo.
When running the browser extension locally connected to Sourcegraph instance including https://github.com/sourcegraph/sourcegraph/pull/50451, we get an error in console: `Error: error during extension "sourcegraph/typescript" activate function: TypeError: c.app.createPanelView is not a function`.
This error doesn't seem to break any browser extension functionality. 


